### PR TITLE
Added Transmiitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,39 @@ cargo xtask build
 
 ## Run
 
-It's inconvenient for now to launch, but if you really
-want it to try, then, please, change in **config/config.yaml** **bpf_objs** path
-to appropriate value and run the following command:
+You can try bombini agent this way:
 
 ```bash
-RUST_LOG=debug cargo xtask run -- --config-dir ./config
+RUST_LOG=debug cargo xtask run -- --config-dir ./config --stdout
+```
+
+Also you can use file as output or unix socket combining with
+[vector](https://github.com/vectordotdev/vector).
+
+### File
+
+Start vector agent:
+
+```bash
+vector --config ./vector/vector-file.yaml
+```
+
+Start bombini with events redirecting to file:
+
+```bash
+RUST_LOG=debug cargo xtask run -- --config-dir ./config --event-log ./bombini.log
+```
+
+### Unix socket
+
+Start vector agent with unix socket listner:
+
+```bash
+vector --config ./vector/vector-sock.yaml
+```
+
+Start bombini with events redirecting to unix socket:
+
+```bash
+RUST_LOG=debug cargo xtask run -- --config-dir ./config --event-socket ./bombini.sock
 ```

--- a/bombini/Cargo.toml
+++ b/bombini/Cargo.toml
@@ -16,7 +16,8 @@ lazy_static = "1.5"
 libc = "0.2"
 log = "0.4"
 procfs = "0.16"
-tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync"] }
+tokio = { version = "1.25", features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "net", "signal", "sync"] }
+futures-executor = "0.3"
 yaml-rust2 = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/bombini/src/config.rs
+++ b/bombini/src/config.rs
@@ -2,7 +2,7 @@
 
 use yaml_rust2::YamlLoader;
 
-use clap::Parser;
+use clap::{Args, Parser};
 use lazy_static::lazy_static;
 use tokio::sync::RwLock;
 
@@ -17,34 +17,53 @@ pub const EVENT_MAP_NAME: &str = "EVENT_MAP";
 #[command(about = "Ebpf-based agent for observability and security monitoring", long_about = None)]
 pub struct Config {
     /// Directory with bpf detector object files
-    #[arg(long, value_name = "FILE", default_value_t = String::from("/home/fedotoff/bombini/target/bpfel-unknown-none/debug"))]
-    pub bpf_objs: String,
+    #[arg(long, value_name = "FILE")]
+    pub bpf_objs: Option<String>,
 
     /// Path to pin bpf maps
-    #[arg(long, value_name = "FILE", default_value_t = String::from("/sys/fs/bpf/bombini"))]
-    pub maps_pin_path: String,
+    #[arg(long, value_name = "FILE")]
+    pub maps_pin_path: Option<String>,
 
     /// Event map size (ring buffer size in bytes)
-    #[arg(long, value_name = "VALUE", default_value_t = 65536)]
-    pub event_map_size: u32,
+    #[arg(long, value_name = "VALUE")]
+    pub event_map_size: Option<u32>,
 
     /// Raw event channel size (number of event messages)
-    #[arg(long, value_name = "VALUE", default_value_t = 64)]
-    pub event_channel_size: usize,
+    #[arg(long, value_name = "VALUE")]
+    pub event_channel_size: Option<usize>,
 
     /// List of detectors to load
     #[arg(long, value_name = "NAMES")]
     pub detectors: Option<Vec<String>>,
 
     /// YAML config dir with global config and detector configs
-    #[arg(long, value_name = "DIR", default_value_t = String::from("/home/fedotoff/bombini/config"))]
+    #[arg(long, value_name = "DIR")]
     pub config_dir: String,
+
+    #[command(flatten)]
+    pub transmit_opts: TransmitterOpts,
+}
+
+#[derive(Default, Clone, Debug, Args)]
+#[group(required = true, multiple = false)]
+pub struct TransmitterOpts {
+    /// Send events to stdout
+    #[arg(long)]
+    pub stdout: bool,
+
+    /// File path to save events
+    #[arg(long, value_name = "FILE")]
+    pub event_log: Option<String>,
+
+    /// Unix socket path to send events
+    #[arg(long, value_name = "FILE")]
+    pub event_socket: Option<String>,
 }
 
 impl Config {
     /// Method returns path for event map pin
     pub fn event_pin_path(&self) -> PathBuf {
-        let mut event_pin = PathBuf::from(&self.maps_pin_path);
+        let mut event_pin = PathBuf::from(self.maps_pin_path.as_ref().unwrap());
         event_pin.push(EVENT_MAP_NAME);
         event_pin
     }
@@ -52,44 +71,64 @@ impl Config {
     /// Creates new config from args and yaml
     pub fn init(&mut self) -> Result<(), anyhow::Error> {
         //TODO: maybe change to serde_yaml
-
-        *self = Config::parse();
+        let args = Config::parse();
+        self.config_dir = args.config_dir.to_string();
 
         let mut config_path = PathBuf::from(&self.config_dir);
         config_path.push("config.yaml"); // Global config name
 
         // YAML overrides command line args.
-        if let Ok(s) = std::fs::read_to_string(&config_path) {
-            let docs = YamlLoader::load_from_str(&s)?;
+        let s = std::fs::read_to_string(&config_path)?;
+        let docs = YamlLoader::load_from_str(&s)?;
 
-            //TODO: accurate checks if value is in yaml than use it, else use from args.
-            let doc = &docs[0];
+        // TODO: check that config has required field
+        let doc = &docs[0];
 
-            if let Some(v) = doc["bpf_objs"].as_str() {
-                self.bpf_objs = v.to_string();
-            }
-
-            if let Some(v) = doc["maps_pin_path"].as_str() {
-                self.maps_pin_path = v.to_string();
-            }
-
-            if let Some(v) = doc["event_map_size"].as_i64() {
-                self.event_map_size = v as u32;
-            }
-
-            if let Some(v) = doc["event_channel_size"].as_i64() {
-                self.event_channel_size = v as usize;
-            }
-
-            if let Some(detectors) = doc["detectors"].as_vec() {
-                self.detectors = Some(
-                    detectors
-                        .iter()
-                        .map(|v| v.as_str().unwrap().to_string())
-                        .collect(),
-                );
-            }
+        if let Some(v) = doc["bpf_objs"].as_str() {
+            self.bpf_objs = Some(v.to_string())
         }
+
+        if let Some(v) = doc["maps_pin_path"].as_str() {
+            self.maps_pin_path = Some(v.to_string());
+        }
+
+        if let Some(v) = doc["event_map_size"].as_i64() {
+            self.event_map_size = Some(v as u32);
+        }
+
+        if let Some(v) = doc["event_channel_size"].as_i64() {
+            self.event_channel_size = Some(v as usize);
+        }
+
+        if let Some(detectors) = doc["detectors"].as_vec() {
+            self.detectors = Some(
+                detectors
+                    .iter()
+                    .map(|v| v.as_str().unwrap().to_string())
+                    .collect(),
+            );
+        }
+
+        // Redefine config from file if command args are set
+        if let Some(v) = args.bpf_objs.as_deref() {
+            self.bpf_objs = Some(v.to_string());
+        }
+        if let Some(v) = args.maps_pin_path.as_deref() {
+            self.maps_pin_path = Some(v.to_string());
+        }
+        if let Some(v) = args.event_map_size {
+            self.event_map_size = Some(v);
+        }
+        if let Some(v) = args.event_channel_size {
+            self.event_channel_size = Some(v);
+        }
+        if let Some(detectors) = args.detectors {
+            self.detectors = Some(detectors.to_vec());
+        }
+
+        // Use transmitter options only from args
+        self.transmit_opts = args.transmit_opts;
+
         Ok(())
     }
 }

--- a/bombini/src/detector/mod.rs
+++ b/bombini/src/detector/mod.rs
@@ -65,7 +65,7 @@ pub trait Detector {
 pub async fn load_ebpf_obj<U: AsRef<Path>>(obj_path: U) -> Result<Ebpf, EbpfError> {
     let config = CONFIG.read().await;
     EbpfLoader::new()
-        .map_pin_path(&config.maps_pin_path)
-        .set_max_entries(EVENT_MAP_NAME, config.event_map_size)
+        .map_pin_path(config.maps_pin_path.as_ref().unwrap())
+        .set_max_entries(EVENT_MAP_NAME, config.event_map_size.unwrap())
         .load_file(obj_path.as_ref())
 }

--- a/bombini/src/main.rs
+++ b/bombini/src/main.rs
@@ -5,11 +5,13 @@ mod config;
 mod detector;
 mod monitor;
 mod registry;
+mod transmitter;
 mod transmuter;
 
 use config::CONFIG;
 use monitor::Monitor;
 use registry::Registry;
+use transmitter::log::LogTransmitter;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -24,12 +26,14 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let _ = std::fs::create_dir(&config.maps_pin_path);
 
+    let transmitter = LogTransmitter;
+
     let mut registry = Registry::new();
     registry.load_detecors().await?;
 
     let event_pin_path = config.event_pin_path();
     let monitor = Monitor::new(event_pin_path.as_path(), config.event_channel_size);
-    monitor.monitor().await;
+    monitor.monitor(transmitter).await;
 
     info!("Waiting for Ctrl-C...");
     signal::ctrl_c().await?;

--- a/bombini/src/monitor.rs
+++ b/bombini/src/monitor.rs
@@ -6,19 +6,21 @@ use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 
 use bytes::Bytes;
-use log::info;
+
+use log::debug;
 
 use std::convert::TryFrom;
 use std::path::Path;
 
 use bombini_common::event::Event;
 
+use crate::transmitter::Transmitter;
 use crate::transmuter::Transmuter;
 
 pub struct Monitor<'a> {
-    pub pin_path: &'a Path,
+    pin_path: &'a Path,
     /// Size of raw event channel
-    pub event_chanel_size: usize,
+    event_chanel_size: usize,
 }
 
 impl<'a> Monitor<'a> {
@@ -26,7 +28,9 @@ impl<'a> Monitor<'a> {
     ///
     /// # Arguments
     ///
-    /// * `channel_size` - size of raw event channel.
+    /// * `path` - pin path to event ring buffer
+    ///
+    /// * `channel_size` - size of raw event channel
     pub fn new<P: Into<&'a Path>>(path: P, chanel_sz: usize) -> Self {
         Monitor {
             pin_path: path.into(),
@@ -35,12 +39,17 @@ impl<'a> Monitor<'a> {
     }
 
     /// Start monitoring the events.
-    pub async fn monitor(&self) {
+    ///
+    /// # Arguments
+    ///
+    /// `transmitter` - interface for sending events
+    pub async fn monitor<T: Transmitter + Send + 'static>(&self, mut transmitter: T) {
         let (tx, mut rx) = mpsc::channel::<Bytes>(self.event_chanel_size);
         let ring_buf = RingBuf::try_from(Map::RingBuf(
             aya::maps::MapData::from_pin(self.pin_path).unwrap(),
         ))
         .unwrap();
+
         let transmuter = Transmuter;
 
         tokio::spawn(async move {
@@ -57,7 +66,10 @@ impl<'a> Monitor<'a> {
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 let s: Event = unsafe { std::ptr::read(message.as_ptr() as *const _) };
-                info!("{}", transmuter.transmute(s).await.unwrap());
+                let data = transmuter.transmute(s).await.unwrap();
+                if (transmitter.transmit(data).await).is_err() {
+                    debug!("failed to transmit event");
+                }
             }
         });
     }

--- a/bombini/src/registry.rs
+++ b/bombini/src/registry.rs
@@ -29,7 +29,7 @@ impl Registry {
             return Ok(());
         };
         let config = CONFIG.read().await;
-        let mut obj_path = PathBuf::from(&config.bpf_objs);
+        let mut obj_path = PathBuf::from(config.bpf_objs.as_ref().unwrap());
         let mut config_path = PathBuf::from(&config.config_dir);
         for name in names.iter().map(|e| e.as_str()) {
             obj_path.push(name);

--- a/bombini/src/transmitter/file.rs
+++ b/bombini/src/transmitter/file.rs
@@ -1,0 +1,42 @@
+//! Transmit serialized event into file
+
+use tokio::fs::{File, OpenOptions};
+use tokio::io::AsyncWriteExt;
+
+use std::path::Path;
+
+use crate::transmitter::Transmitter;
+
+pub struct FileTransmitter {
+    file: File,
+}
+
+impl FileTransmitter {
+    /// Construct transmitter for sending events to file.
+    /// File options: create + append
+    pub async fn new<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path.as_ref())
+            .await?;
+        Ok(FileTransmitter { file })
+    }
+}
+
+impl Drop for FileTransmitter {
+    fn drop(&mut self) {
+        futures_executor::block_on(async {
+            self.file.shutdown().await.unwrap();
+        });
+    }
+}
+
+impl Transmitter for FileTransmitter {
+    async fn transmit(&mut self, mut data: Vec<u8>) -> Result<(), anyhow::Error> {
+        // delimiter
+        data.push(b'\n');
+        self.file.write_all(&data).await?;
+        Ok(())
+    }
+}

--- a/bombini/src/transmitter/log.rs
+++ b/bombini/src/transmitter/log.rs
@@ -1,0 +1,14 @@
+//! Transmit serialized event into log
+
+use log::info;
+
+use super::Transmitter;
+
+/// logger log::* must be initialized before
+pub struct LogTransmitter;
+
+impl Transmitter for LogTransmitter {
+    async fn transmit(&mut self, data: Vec<u8>) -> Result<(), anyhow::Error> {
+        Ok(info!("{}", String::from_utf8(data)?))
+    }
+}

--- a/bombini/src/transmitter/mod.rs
+++ b/bombini/src/transmitter/mod.rs
@@ -1,0 +1,17 @@
+//! Transmitter provides interface to send serialized event into different sources
+
+pub mod file;
+pub mod log;
+pub mod unix_sock;
+
+pub trait Transmitter {
+    /// Transmit serialized event
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - serialized event data
+    fn transmit(
+        &mut self,
+        data: Vec<u8>,
+    ) -> impl std::future::Future<Output = Result<(), anyhow::Error>> + Send;
+}

--- a/bombini/src/transmitter/unix_sock.rs
+++ b/bombini/src/transmitter/unix_sock.rs
@@ -1,0 +1,56 @@
+//! Transmit serialized event into unix socket as client
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+
+use std::path::Path;
+
+use crate::transmitter::Transmitter;
+
+use log::debug;
+
+pub struct USockTransmitter {
+    stream: UnixStream,
+}
+
+impl USockTransmitter {
+    /// Connect to unix socket
+    pub async fn new<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
+        let transmitter = USockTransmitter {
+            stream: UnixStream::connect(path.as_ref()).await?,
+        };
+        debug!("Connected to {}", path.as_ref().display());
+        Ok(transmitter)
+    }
+}
+
+impl Drop for USockTransmitter {
+    fn drop(&mut self) {
+        futures_executor::block_on(async {
+            self.stream.shutdown().await.unwrap();
+        });
+    }
+}
+
+impl Transmitter for USockTransmitter {
+    async fn transmit(&mut self, mut data: Vec<u8>) -> Result<(), anyhow::Error> {
+        // Delimiter
+        data.push(b'\n');
+        loop {
+            self.stream.writable().await?;
+            match self.stream.try_write(&data) {
+                Ok(_) => {
+                    debug!("send");
+                    break;
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    continue;
+                }
+                Err(e) => {
+                    return Err(e.into());
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/bombini/src/transmitter/unix_sock.rs
+++ b/bombini/src/transmitter/unix_sock.rs
@@ -40,7 +40,6 @@ impl Transmitter for USockTransmitter {
             self.stream.writable().await?;
             match self.stream.try_write(&data) {
                 Ok(_) => {
-                    debug!("send");
                     break;
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {

--- a/bombini/src/transmuter/mod.rs
+++ b/bombini/src/transmuter/mod.rs
@@ -14,10 +14,10 @@ pub struct Transmuter;
 
 impl Transmuter {
     /// Transmutes bombini_common::Event into serialized formats
-    pub async fn transmute(&self, event: Event) -> Result<String, anyhow::Error> {
+    pub async fn transmute(&self, event: Event) -> Result<Vec<u8>, anyhow::Error> {
         match event {
-            Event::Simple(s) => Ok(SimpleEvent::new(s).to_json()?),
-            Event::GTFOBins(s) => Ok(GTFOBinsEvent::new(s).to_json()?),
+            Event::Simple(s) => Ok(SimpleEvent::new(s).to_json()?.into_bytes()),
+            Event::GTFOBins(s) => Ok(GTFOBinsEvent::new(s).to_json()?.into_bytes()),
         }
     }
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,7 +1,7 @@
 # Global parameters for bombini agent
 ---
 # Directory with bpf detector object files
-bpf_objs: /home/fedotoff/bombini/target/bpfel-unknown-none/debug
+bpf_objs: ./target/bpfel-unknown-none/debug
 
 # Path to pin bpf maps.
 maps_pin_path: /sys/fs/bpf/bombini

--- a/docs/design.md
+++ b/docs/design.md
@@ -26,9 +26,9 @@ Transmuter converts (transmutes) low kernel event into serializable (json, for
 example) data structure. It also can enrich kernel event with some user mode
 data.
 
-### Transmiter (not implemented yet)
+### Transmiter
 
-Transmiter sends event to different sources (network, stdout, file).
+Transmiter sends serialized events (byte arrays) to different sources (unix socket, stdout, file, etc).
 
 ### Config
 

--- a/vector/vector-file.yaml
+++ b/vector/vector-file.yaml
@@ -1,0 +1,38 @@
+#                                    __   __  __
+#                                    \ \ / / / /
+#                                     \ V / / /
+#                                      \_/  \/
+#
+#                                    V E C T O R
+#                                   Configuration
+#
+# ------------------------------------------------------------------------------
+# Website: https://vector.dev
+# Docs: https://vector.dev/docs
+# Chat: https://chat.vector.dev
+# ------------------------------------------------------------------------------
+
+# Change this to use a non-default directory for Vector data storage:
+data_dir: "/tmp/vector"
+
+sources:
+  bombini_log:
+    type: "file"
+    include: ["/home/**/bombini/bombini.log"]
+    line_delimiter: "\n"
+
+transforms:
+  parse_logs:
+    type: "remap"
+    inputs: ["bombini_log"]
+    source: |
+      . = parse_json!(string!(.message))
+
+sinks:
+  print:
+    type: "console"
+    inputs: ["parse_logs"]
+    encoding:
+      codec: "json"
+      json:
+        pretty: true

--- a/vector/vector-sock.yaml
+++ b/vector/vector-sock.yaml
@@ -1,0 +1,35 @@
+#                                    __   __  __
+#                                    \ \ / / / /
+#                                     \ V / / /
+#                                      \_/  \/
+#
+#                                    V E C T O R
+#                                   Configuration
+#
+# ------------------------------------------------------------------------------
+# Website: https://vector.dev
+# Docs: https://vector.dev/docs
+# Chat: https://chat.vector.dev
+# ------------------------------------------------------------------------------
+
+# Change this to use a non-default directory for Vector data storage:
+data_dir: "/tmp/vector"
+
+sources:
+  bombini_sock:
+    type: "socket"
+    path: "/home/fedotoff/bombini/bombini.sock"
+    mode: "unix_stream"
+    framing:
+      method: "newline_delimited"
+    decoding:
+      codec: "json"
+
+sinks:
+  print:
+    type: "console"
+    inputs: ["bombini_sock"]
+    encoding:
+      codec: "json"
+      json:
+        pretty: true


### PR DESCRIPTION
Transmitter sends serialized data to different sources. Implemented log transmitter that uses log:: macroses to send events. Implemented file transmitter that writes event to file. Implemented unix socket transmitter that connects as client to socket and sends event.
Provided examples of vector (https://vector.dev) configs for file and socket transmitters.