### PR TITLE
Add new detector ProcMon. New logic for GTFOBins detector

### DIFF
--- a/bombini-common/src/config/gtfobins.rs
+++ b/bombini-common/src/config/gtfobins.rs
@@ -1,7 +1,5 @@
 //! GTFOBins config
 
-pub const MAX_FILENAME_SIZE: usize = 32;
-
-pub const MAX_ARGS_SIZE: usize = 256;
+use crate::event::process::MAX_FILENAME_SIZE;
 
 pub type GTFOBinsKey = [u8; MAX_FILENAME_SIZE];

--- a/bombini-common/src/event/gtfobins.rs
+++ b/bombini-common/src/event/gtfobins.rs
@@ -1,21 +1,10 @@
 //! GTFOBins event module
 
-use crate::config::gtfobins::{MAX_ARGS_SIZE, MAX_FILENAME_SIZE};
+use crate::event::process::ProcInfo;
 
 /// GTFOBins execution event
 #[derive(Clone, Debug)]
 #[repr(C)]
 pub struct GTFOBinsMsg {
-    /// UID
-    pub uid: u32,
-    /// EUID
-    pub euid: u32,
-    /// if CAP_SET_UID is set in effective capabilities
-    pub is_cap_set_uid: bool,
-    /// if SETUID executable
-    pub is_suid: bool,
-    /// executable name
-    pub filename: [u8; MAX_FILENAME_SIZE],
-    /// command line arguments without argv[0]
-    pub args: [u8; MAX_ARGS_SIZE],
+    pub process: ProcInfo,
 }

--- a/bombini-common/src/event/mod.rs
+++ b/bombini-common/src/event/mod.rs
@@ -1,5 +1,7 @@
 //! Event module provide generic event message for all detectors
 
+pub mod process;
+
 /// Event messages
 pub mod gtfobins;
 pub mod simple;

--- a/bombini-common/src/event/process.rs
+++ b/bombini-common/src/event/process.rs
@@ -1,0 +1,27 @@
+//! Process event module
+
+pub const MAX_FILENAME_SIZE: usize = 32;
+
+pub const MAX_ARGS_SIZE: usize = 256;
+
+/// Process event
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ProcInfo {
+    /// PID
+    pub pid: u32,
+    /// TID
+    pub tid: u32,
+    /// UID
+    pub uid: u32,
+    /// EUID
+    pub euid: u32,
+    /// if CAP_SET_UID is set in effective capabilities
+    pub is_cap_set_uid: bool,
+    /// if SETUID executable
+    pub is_suid: bool,
+    /// executable name
+    pub filename: [u8; MAX_FILENAME_SIZE],
+    /// command line arguments without argv[0]
+    pub args: [u8; MAX_ARGS_SIZE],
+}

--- a/bombini-detectors-ebpf/src/bin/procmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/procmon/main.rs
@@ -1,0 +1,119 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{
+    bindings::BPF_ANY,
+    helpers::{
+        bpf_get_current_pid_tgid, bpf_get_current_task, bpf_probe_read,
+        bpf_probe_read_kernel_str_bytes, bpf_probe_read_user_buf, bpf_probe_read_user_str_bytes,
+    },
+    macros::{kprobe, map, tracepoint},
+    maps::{hash_map::HashMap, per_cpu_array::PerCpuArray},
+    programs::{ProbeContext, TracePointContext},
+};
+
+use bombini_detectors_ebpf::vmlinux::{
+    cred, file, inode, kernel_cap_t, kuid_t, mm_struct, path, pid_t, qstr, task_struct, umode_t,
+};
+
+use bombini_common::event::process::{ProcInfo, MAX_ARGS_SIZE, MAX_FILENAME_SIZE};
+
+const S_ISUID: u16 = 0x0004000;
+
+#[map]
+static PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
+
+#[map]
+static HEAP: PerCpuArray<ProcInfo> = PerCpuArray::with_max_entries(1, 0);
+
+#[tracepoint]
+pub fn execve_capture(ctx: TracePointContext) -> u32 {
+    match try_capture(ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+fn try_capture(_ctx: TracePointContext) -> Result<u32, u32> {
+    let Some(proc_ptr) = HEAP.get_ptr_mut(0) else {
+        return Err(0);
+    };
+
+    let proc = unsafe { proc_ptr.as_mut() };
+
+    let Some(proc) = proc else {
+        return Err(0);
+    };
+
+    // We need to read real executable name and get arguments from stack.
+    let (arg_start, arg_end) = unsafe {
+        let task = bpf_get_current_task() as *const task_struct;
+        proc.pid = bpf_probe_read::<pid_t>(&(*task).pid as *const _).map_err(|e| e as u32)? as u32;
+        proc.tid = bpf_probe_read::<pid_t>(&(*task).tgid as *const _).map_err(|e| e as u32)? as u32;
+
+        let mm =
+            bpf_probe_read::<*mut mm_struct>(&(*task).mm as *const *mut _).map_err(|e| e as u32)?;
+        let mut arg_start = bpf_probe_read::<u64>(&(*mm).__bindgen_anon_1.arg_start as *const _)
+            .map_err(|e| e as u32)?;
+
+        let arg_end = bpf_probe_read::<u64>(&(*mm).__bindgen_anon_1.arg_end as *const _)
+            .map_err(|e| e as u32)?;
+        let file = bpf_probe_read::<*mut file>(&(*mm).__bindgen_anon_1.exe_file as *const *mut _)
+            .map_err(|e| e as u32)?;
+        let path = bpf_probe_read::<path>(&(*file).f_path as *const _).map_err(|e| e as u32)?;
+        let d_name =
+            bpf_probe_read::<qstr>(&(*(path.dentry)).d_name as *const _).map_err(|e| e as u32)?;
+        let inode = bpf_probe_read::<*mut inode>(&(*file).f_inode as *const *mut _)
+            .map_err(|e| e as u32)?;
+        let i_mode =
+            bpf_probe_read::<umode_t>(&(*inode).i_mode as *const _).map_err(|e| e as u32)?;
+
+        aya_ebpf::memset(proc.filename.as_mut_ptr(), 0, MAX_FILENAME_SIZE);
+        bpf_probe_read_kernel_str_bytes(d_name.name, &mut proc.filename).map_err(|e| e as u32)?;
+        aya_ebpf::memset(proc.args.as_mut_ptr(), 0, MAX_ARGS_SIZE);
+
+        // Skip argv[0]
+        let first_arg = bpf_probe_read_user_str_bytes(arg_start as *const u8, &mut proc.args)
+            .map_err(|e| e as u32)?;
+
+        arg_start += 1 + first_arg.len() as u64;
+
+        // Get cred
+        let cred = bpf_probe_read::<*const cred>(&(*task).cred as *const *const _)
+            .map_err(|e| e as u32)?;
+        let euid = bpf_probe_read::<kuid_t>(&(*cred).euid as *const _).map_err(|e| e as u32)?;
+        let uid = bpf_probe_read::<kuid_t>(&(*cred).uid as *const _).map_err(|e| e as u32)?;
+
+        proc.uid = uid.val;
+        proc.euid = euid.val;
+        let cap_e = bpf_probe_read::<kernel_cap_t>(&(*cred).cap_effective as *const _)
+            .map_err(|e| e as u32)?;
+
+        proc.is_cap_set_uid = (cap_e.val & 128) != 0;
+        proc.is_suid = (i_mode & S_ISUID) != 0;
+
+        (arg_start, arg_end)
+    };
+    let arg_size = (arg_end - arg_start) & (MAX_ARGS_SIZE - 1) as u64;
+    unsafe {
+        bpf_probe_read_user_buf(arg_start as *const u8, &mut proc.args[..arg_size as usize])
+            .map_err(|e| e as u32)?;
+    }
+
+    PROC_MAP
+        .insert(&proc.pid, proc, BPF_ANY as u64)
+        .map_err(|e| e as u32)?;
+    Ok(0)
+}
+
+#[kprobe]
+pub fn exit_capture(_ctx: ProbeContext) -> u32 {
+    let pid = bpf_get_current_pid_tgid() as u32;
+    PROC_MAP.remove(&pid).unwrap();
+    0
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}

--- a/bombini/src/detector/mod.rs
+++ b/bombini/src/detector/mod.rs
@@ -11,6 +11,7 @@ use anyhow::anyhow;
 use crate::config::{CONFIG, EVENT_MAP_NAME};
 
 pub mod gtfobins;
+pub mod procmon;
 pub mod simple;
 
 pub trait Detector {

--- a/bombini/src/detector/procmon.rs
+++ b/bombini/src/detector/procmon.rs
@@ -1,0 +1,47 @@
+//! Detector for Process executions and exits
+
+use aya::programs::{KProbe, TracePoint};
+use aya::{Ebpf, EbpfError};
+
+use procfs::sys::kernel::Version;
+
+use std::path::Path;
+
+use super::{load_ebpf_obj, Detector};
+
+pub struct ProcMon {
+    ebpf: Ebpf,
+}
+
+impl Detector for ProcMon {
+    fn min_kenrel_verison(&self) -> Version {
+        Version::new(5, 8, 0)
+    }
+
+    async fn new<U: AsRef<Path>>(
+        obj_path: U,
+        _config_path: Option<U>,
+    ) -> Result<Self, anyhow::Error> {
+        let ebpf = load_ebpf_obj(obj_path).await?;
+        Ok(ProcMon { ebpf })
+    }
+
+    fn map_initialize(&mut self) -> Result<(), EbpfError> {
+        Ok(())
+    }
+
+    fn load_and_attach_programs(&mut self) -> Result<(), EbpfError> {
+        let exec: &mut TracePoint = self
+            .ebpf
+            .program_mut("execve_capture")
+            .unwrap()
+            .try_into()?;
+        exec.load()?;
+        exec.attach("sched", "sched_process_exec")?;
+
+        let exit: &mut KProbe = self.ebpf.program_mut("exit_capture").unwrap().try_into()?;
+        exit.load()?;
+        exit.attach("acct_process", 0)?;
+        Ok(())
+    }
+}

--- a/bombini/src/main.rs
+++ b/bombini/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     info!("Waiting for Ctrl-C...");
     signal::ctrl_c().await?;
-    let _ = std::fs::remove_file(&event_pin_path);
+    let _ = std::fs::remove_dir_all(config.maps_pin_path.as_ref().unwrap());
     info!("Exiting...");
 
     Ok(())

--- a/bombini/src/registry.rs
+++ b/bombini/src/registry.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 use crate::config::CONFIG;
 use crate::detector::gtfobins::GTFOBinsDetector;
+use crate::detector::procmon::ProcMon;
 use crate::detector::simple::SimpleDetector;
 use crate::detector::Detector;
 
@@ -44,6 +45,11 @@ impl Registry {
                     let mut detector = GTFOBinsDetector::new(&obj_path, Some(&config_path)).await?;
                     detector.load()?;
                     self.detectors.insert(name.to_string(), Box::new(detector));
+                }
+                "procmon" => {
+                    let mut procmon = ProcMon::new(&obj_path, None).await?;
+                    procmon.load()?;
+                    self.detectors.insert(name.to_string(), Box::new(procmon));
                 }
                 _ => return Err(anyhow!("{} unknown detector", name)),
             };

--- a/bombini/src/transmuter/gtfobins.rs
+++ b/bombini/src/transmuter/gtfobins.rs
@@ -25,23 +25,30 @@ pub struct GTFOBinsEvent {
 impl GTFOBinsEvent {
     /// Constructs High level event representation from low eBPF
     pub fn new(mut event: GTFOBinsMsg) -> Self {
-        let filename = if *event.filename.last().unwrap() == 0x0 {
-            let zero = event.filename.iter().position(|e| *e == 0x0).unwrap();
-            String::from_utf8_lossy(&event.filename[..zero]).to_string()
+        let filename = if *event.process.filename.last().unwrap() == 0x0 {
+            let zero = event
+                .process
+                .filename
+                .iter()
+                .position(|e| *e == 0x0)
+                .unwrap();
+            String::from_utf8_lossy(&event.process.filename[..zero]).to_string()
         } else {
-            String::from_utf8_lossy(&event.filename).to_string()
+            String::from_utf8_lossy(&event.process.filename).to_string()
         };
-        event.args.iter_mut().for_each(|e| {
+        event.process.args.iter_mut().for_each(|e| {
             if *e == 0x00 {
                 *e = 0x20
             }
         });
-        let args = String::from_utf8_lossy(&event.args).trim_end().to_string();
+        let args = String::from_utf8_lossy(&event.process.args)
+            .trim_end()
+            .to_string();
         Self {
-            uid: event.uid,
-            euid: event.euid,
-            is_cap_set_uid: event.is_cap_set_uid,
-            is_suid: event.is_suid,
+            uid: event.process.uid,
+            euid: event.process.euid,
+            is_cap_set_uid: event.process.is_cap_set_uid,
+            is_suid: event.process.is_suid,
             filename,
             args,
         }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,5 +14,6 @@ event_channel_size: 64
 
 # List of the detectors to load
 detectors:
+   - procmon
    - simple
    - gtfobins


### PR DESCRIPTION
Add new detector ProcMon. ProcMon puts process info at process start (execve) to the hash map and removes it when process is finished. Procmon doesn't fire any events.

GTFOBins now has new logic. When binary is executed two checks are made:
1. Is parent process binary is from GTFOBins map.
2. Is current executed binary is one of sh, bash, dash, zsh.