### PR TITLE
HistFile detector to check if user stops writing bash history

### DIFF
--- a/bombini-common/src/event/histfile.rs
+++ b/bombini-common/src/event/histfile.rs
@@ -1,0 +1,11 @@
+//! Histfile event module
+
+pub const MAX_BASH_COMMAND_SIZE: usize = 128;
+
+/// Histfile execution event
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct HistFileMsg {
+    /// bash read line
+    pub command: [u8; MAX_BASH_COMMAND_SIZE],
+}

--- a/bombini-common/src/event/mod.rs
+++ b/bombini-common/src/event/mod.rs
@@ -4,6 +4,7 @@ pub mod process;
 
 /// Event messages
 pub mod gtfobins;
+pub mod histfile;
 
 /// Generic event for ring buffer
 #[allow(clippy::large_enum_variant)]
@@ -13,9 +14,13 @@ pub enum Event {
     /// 0 - 31 reserved for common events
     /// GTFOBins execution event type
     GTFOBins(gtfobins::GTFOBinsMsg) = 32,
+    /// Histfile modification event type
+    HistFile(histfile::HistFileMsg) = 33,
 }
 
 // Event message codes
 
 /// GTFOBins execution message code
 pub const MSG_GTFOBINS: u8 = 32;
+/// HISTFILESIZE/HISTSIZE modification message code
+pub const MSG_HISTFILE: u8 = 33;

--- a/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
+++ b/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
@@ -34,7 +34,9 @@ pub fn gtfobins_detect(ctx: LsmContext) -> i32 {
 }
 
 fn try_detect(ctx: LsmContext, event: &mut Event) -> Result<u32, u32> {
-    let Event::GTFOBins(event) = event;
+    let Event::GTFOBins(event) = event else {
+        return Err(0);
+    };
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
     let proc = unsafe { PROC_MAP.get(&pid) };
     let Some(proc) = proc else {

--- a/bombini-detectors-ebpf/src/bin/histfile/main.rs
+++ b/bombini-detectors-ebpf/src/bin/histfile/main.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{
+    helpers::bpf_probe_read_user_str_bytes,
+    macros::{map, uretprobe},
+    maps::lpm_trie::{Key, LpmTrie},
+    programs::retprobe::RetProbeContext,
+};
+
+use bombini_common::event::histfile::MAX_BASH_COMMAND_SIZE;
+use bombini_common::event::{Event, MSG_HISTFILE};
+use bombini_detectors_ebpf::{event_capture, event_map::rb_event_init};
+
+#[map]
+static HIST_CHECK_MAP: LpmTrie<[u8; MAX_BASH_COMMAND_SIZE], u32> = LpmTrie::with_max_entries(2, 0);
+
+#[uretprobe]
+pub fn histfile_detect(ctx: RetProbeContext) -> i32 {
+    event_capture!(ctx, MSG_HISTFILE, try_detect) as i32
+}
+
+fn try_detect(ctx: RetProbeContext, event: &mut Event) -> Result<u32, u32> {
+    let Event::HistFile(event) = event else {
+        return Err(0);
+    };
+    let command: *const u8 = ctx.ret().ok_or(0u32)?;
+    unsafe {
+        aya_ebpf::memset(event.command.as_mut_ptr(), 0, MAX_BASH_COMMAND_SIZE);
+        bpf_probe_read_user_str_bytes(command, &mut event.command).map_err(|e| e as u32)?;
+    }
+    let lookup = Key::new((MAX_BASH_COMMAND_SIZE * 8) as u32, event.command);
+    if HIST_CHECK_MAP.get(&lookup).is_some() {
+        Ok(0)
+    } else {
+        Err(0)
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}

--- a/bombini/src/detector/histfile.rs
+++ b/bombini/src/detector/histfile.rs
@@ -1,0 +1,58 @@
+//! Histfile detector
+
+use bombini_common::event::histfile::MAX_BASH_COMMAND_SIZE;
+
+use aya::maps::lpm_trie::{Key, LpmTrie};
+use aya::programs::UProbe;
+use aya::{Ebpf, EbpfError};
+
+use procfs::sys::kernel::Version;
+
+use std::path::Path;
+
+use super::{load_ebpf_obj, Detector};
+
+pub struct HistFileDetector {
+    ebpf: Ebpf,
+}
+
+impl Detector for HistFileDetector {
+    fn min_kenrel_verison(&self) -> Version {
+        Version::new(5, 8, 0)
+    }
+
+    async fn new<U: AsRef<Path>>(
+        obj_path: U,
+        _config_path: Option<U>,
+    ) -> Result<Self, anyhow::Error> {
+        let ebpf = load_ebpf_obj(obj_path).await?;
+        Ok(HistFileDetector { ebpf })
+    }
+
+    fn map_initialize(&mut self) -> Result<(), EbpfError> {
+        let mut hist_fsz_buf = [0; MAX_BASH_COMMAND_SIZE];
+        let mut hist_sz_buf = [0; MAX_BASH_COMMAND_SIZE];
+        let hist_fsz_str = "export HISTFILESIZE=0";
+        let hist_sz_str = "export HISTSIZE=0";
+        hist_fsz_buf[..hist_fsz_str.len()].clone_from_slice(hist_fsz_str.as_bytes());
+        hist_sz_buf[..hist_sz_str.len()].clone_from_slice(hist_sz_str.as_bytes());
+        let hist_fsz_key = Key::new((hist_fsz_str.len() * 8) as u32, hist_fsz_buf);
+        let hist_sz_key = Key::new((hist_sz_str.len() * 8) as u32, hist_sz_buf);
+        let mut hist_cmds: LpmTrie<_, [u8; MAX_BASH_COMMAND_SIZE], u32> =
+            LpmTrie::try_from(self.ebpf.map_mut("HIST_CHECK_MAP").unwrap())?;
+        hist_cmds.insert(&hist_fsz_key, 1, 0)?;
+        hist_cmds.insert(&hist_sz_key, 1, 0)?;
+        Ok(())
+    }
+
+    fn load_and_attach_programs(&mut self) -> Result<(), EbpfError> {
+        let program: &mut UProbe = self
+            .ebpf
+            .program_mut("histfile_detect")
+            .unwrap()
+            .try_into()?;
+        program.load()?;
+        program.attach(Some("readline"), 0, "/bin/bash", None)?;
+        Ok(())
+    }
+}

--- a/bombini/src/detector/mod.rs
+++ b/bombini/src/detector/mod.rs
@@ -11,6 +11,7 @@ use anyhow::anyhow;
 use crate::config::{CONFIG, EVENT_MAP_NAME};
 
 pub mod gtfobins;
+pub mod histfile;
 pub mod procmon;
 
 pub trait Detector {

--- a/bombini/src/registry.rs
+++ b/bombini/src/registry.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 
 use crate::config::CONFIG;
 use crate::detector::gtfobins::GTFOBinsDetector;
+use crate::detector::histfile::HistFileDetector;
+
 use crate::detector::procmon::ProcMon;
 use crate::detector::Detector;
 
@@ -37,6 +39,11 @@ impl Registry {
             match name {
                 "gtfobins" => {
                     let mut detector = GTFOBinsDetector::new(&obj_path, Some(&config_path)).await?;
+                    detector.load()?;
+                    self.detectors.insert(name.to_string(), Box::new(detector));
+                }
+                "histfile" => {
+                    let mut detector = HistFileDetector::new(&obj_path, None).await?;
                     detector.load()?;
                     self.detectors.insert(name.to_string(), Box::new(detector));
                 }

--- a/bombini/src/transmuter/histfile.rs
+++ b/bombini/src/transmuter/histfile.rs
@@ -1,0 +1,31 @@
+//! Transmutes HistFileEvent to serialized format
+
+use bombini_common::event::histfile::HistFileMsg;
+
+use serde::Serialize;
+
+/// High-level event representation
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type")]
+pub struct HistFileEvent {
+    /// bash command
+    pub command: String,
+}
+
+impl HistFileEvent {
+    /// Constructs High level event representation from low eBPF
+    pub fn new(event: HistFileMsg) -> Self {
+        let command = if *event.command.last().unwrap() == 0x0 {
+            let zero = event.command.iter().position(|e| *e == 0x0).unwrap();
+            String::from_utf8_lossy(&event.command[..zero]).to_string()
+        } else {
+            String::from_utf8_lossy(&event.command).to_string()
+        };
+        Self { command }
+    }
+
+    /// Get JSON reprsentation
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(&self)
+    }
+}

--- a/bombini/src/transmuter/mod.rs
+++ b/bombini/src/transmuter/mod.rs
@@ -4,8 +4,10 @@
 use bombini_common::event::Event;
 
 use gtfobins::GTFOBinsEvent;
+use histfile::HistFileEvent;
 
 mod gtfobins;
+mod histfile;
 
 /// Transmutes eBPF events from low representation into serialized formats
 pub struct Transmuter;
@@ -15,6 +17,7 @@ impl Transmuter {
     pub async fn transmute(&self, event: Event) -> Result<Vec<u8>, anyhow::Error> {
         match event {
             Event::GTFOBins(s) => Ok(GTFOBinsEvent::new(s).to_json()?.into_bytes()),
+            Event::HistFile(s) => Ok(HistFileEvent::new(s).to_json()?.into_bytes()),
         }
     }
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,3 +16,4 @@ event_channel_size: 64
 detectors:
    - procmon
    - gtfobins
+   - histfile

--- a/docs/design.md
+++ b/docs/design.md
@@ -40,10 +40,23 @@ load during start up.
 Registry stores loaded detectors. It can load/unload detectors and possibly
 interact with them (change config maps).
 
-## Examples of Detectors
+## List of the Detectors
 
 ## GTFObins
 
 GTFOBins detector tries to detect [GTFOBins](https://gtfobins.github.io/) execution.
 It checks if privileged binary is executed and returns the binary name with
 command line args as an event. List of GTFOBins is provided in YAML config.
+
+## HistFile
+
+HistFile detector's goal is to detect cases when user stops writing bash
+history to `~/.bash_history`. It can be done using this commands:
+
+```bash
+export HISTFILESIZE=0
+export HISTSIZE=0
+```
+
+Detector attaches to `/bin/bash` `readline` func with uretprobe and uses **lpm_trie**
+map to check for commands above.


### PR DESCRIPTION
Add HistFile detector. The goal is to detect cases when user stops writing bash history to ~/.bash_history. It can be done using this commands:

export HISTFILESIZE=0
export HISTSIZE=0

Detector attaches to /bin/bash readline func with uretprobe and uses lpm_trie map to check for commands above.