### PR TITLE
Refactor ProcMon

### DIFF
--- a/bombini-common/Cargo.toml
+++ b/bombini-common/Cargo.toml
@@ -9,6 +9,7 @@ user = ["aya"]
 
 [dependencies]
 aya = { version = "0.13", optional = true }
+bitflags = { version = "2.8.0"}
 
 [lib]
 path = "src/lib.rs"

--- a/bombini-common/src/event/process.rs
+++ b/bombini-common/src/event/process.rs
@@ -1,8 +1,12 @@
 //! Process event module
 
+use bitflags::bitflags;
+
 pub const MAX_FILENAME_SIZE: usize = 32;
 
 pub const MAX_ARGS_SIZE: usize = 256;
+
+pub const MAX_FILE_PATH: usize = 256;
 
 /// Process event
 #[derive(Clone, Debug)]
@@ -15,16 +19,38 @@ pub struct ProcInfo {
     pub tid: u32,
     /// Parent PID
     pub ppid: u32,
+    /// Task Creds
+    pub creds: Cred,
+    /// login UID
+    pub auid: u32,
+    /// executable name
+    pub filename: [u8; MAX_FILENAME_SIZE],
+    /// full binary path
+    pub binary_path: [u8; MAX_FILE_PATH],
+    /// command line arguments without argv[0]
+    pub args: [u8; MAX_ARGS_SIZE],
+}
+
+/// Creds
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct Cred {
     /// UID
     pub uid: u32,
     /// EUID
     pub euid: u32,
-    /// if CAP_SET_UID is set in effective capabilities
-    pub is_cap_set_uid: bool,
-    /// if SETUID executable
-    pub is_suid: bool,
-    /// executable name
-    pub filename: [u8; MAX_FILENAME_SIZE],
-    /// command line arguments without argv[0]
-    pub args: [u8; MAX_ARGS_SIZE],
+    pub cap_inheritable: u64,
+    pub cap_permitted: u64,
+    pub cap_effective: u64,
+    pub secureexec: SecureExec,
+}
+
+bitflags! {
+    #[derive(Clone, Debug, PartialEq)]
+    #[repr(C)]
+    pub struct SecureExec: u32 {
+        const SETUID = 0b00000001;
+        const SETGID = 0b00000010;
+        const FILE_CAPS = 0b00000100;
+    }
 }

--- a/bombini-detectors-ebpf/Cargo.toml
+++ b/bombini-detectors-ebpf/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 aya-ebpf = "0.1"
 aya-log-ebpf = "0.1"
 bombini-common = { path = "../bombini-common" }
+bitflags = { version = "2.8.0"}
 
 [profile.dev]
 opt-level = 3

--- a/bombini-detectors-ebpf/src/bin/procmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/procmon/main.rs
@@ -4,41 +4,75 @@
 use aya_ebpf::{
     bindings::BPF_ANY,
     helpers::{
-        bpf_get_current_pid_tgid, bpf_get_current_task, bpf_ktime_get_ns, bpf_probe_read,
-        bpf_probe_read_kernel_buf, bpf_probe_read_kernel_str_bytes, bpf_probe_read_user_buf,
-        bpf_probe_read_user_str_bytes,
+        bpf_d_path, bpf_get_current_pid_tgid, bpf_get_current_task, bpf_ktime_get_ns,
+        bpf_probe_read, bpf_probe_read_kernel_buf, bpf_probe_read_kernel_str_bytes,
+        bpf_probe_read_user_buf, bpf_probe_read_user_str_bytes,
     },
-    macros::{kprobe, map, tracepoint},
+    macros::{btf_tracepoint, fentry, lsm, map},
     maps::{hash_map::HashMap, per_cpu_array::PerCpuArray},
-    programs::{ProbeContext, TracePointContext},
+    programs::{BtfTracePointContext, FEntryContext, LsmContext},
 };
 
 use bombini_detectors_ebpf::vmlinux::{
-    cred, file, inode, kernel_cap_t, kuid_t, mm_struct, path, pid_t, qstr, task_struct, umode_t,
+    cred, file, kernel_cap_t, kgid_t, kuid_t, linux_binprm, mm_struct, path, pid_t, qstr,
+    task_struct,
 };
 
-use bombini_common::event::process::{ProcInfo, MAX_ARGS_SIZE};
+use bombini_common::event::process::{ProcInfo, SecureExec, MAX_ARGS_SIZE, MAX_FILE_PATH};
 
-const S_ISUID: u16 = 0x0004000;
+/// Extra info from bprm_committing_creds hook
+struct CredSharedInfo {
+    pub secureexec: SecureExec,
+    /// full binary path
+    pub binary_path: [u8; MAX_FILE_PATH],
+}
 
 #[map]
 static PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
 
 #[map]
+static CRED_SHARED_MAP: HashMap<u64, CredSharedInfo> = HashMap::pinned(1024, 0);
+
+#[map]
+static CRED_HEAP: PerCpuArray<CredSharedInfo> = PerCpuArray::with_max_entries(1, 0);
+
+#[map]
 static HEAP: PerCpuArray<ProcInfo> = PerCpuArray::with_max_entries(1, 0);
 
-#[tracepoint]
-pub fn execve_capture(ctx: TracePointContext) -> u32 {
+#[btf_tracepoint(function = "sched_process_exec")]
+pub fn execve_capture(ctx: BtfTracePointContext) -> u32 {
     match try_capture(ctx) {
         Ok(ret) => ret,
         Err(ret) => ret,
     }
 }
 
-fn try_capture(_ctx: TracePointContext) -> Result<u32, u32> {
+#[inline(always)]
+unsafe fn get_creds(proc: &mut ProcInfo, task: *const task_struct) -> Result<u32, u32> {
+    let cred =
+        bpf_probe_read::<*const cred>(&(*task).cred as *const *const _).map_err(|e| e as u32)?;
+    let euid = bpf_probe_read::<kuid_t>(&(*cred).euid as *const _).map_err(|e| e as u32)?;
+    let uid = bpf_probe_read::<kuid_t>(&(*cred).uid as *const _).map_err(|e| e as u32)?;
+    let cap_e =
+        bpf_probe_read::<kernel_cap_t>(&(*cred).cap_effective as *const _).map_err(|e| e as u32)?;
+    let cap_i = bpf_probe_read::<kernel_cap_t>(&(*cred).cap_inheritable as *const _)
+        .map_err(|e| e as u32)?;
+    let cap_p =
+        bpf_probe_read::<kernel_cap_t>(&(*cred).cap_permitted as *const _).map_err(|e| e as u32)?;
+
+    proc.creds.uid = uid.val;
+    proc.creds.euid = euid.val;
+    proc.creds.cap_effective = cap_e.val;
+    proc.creds.cap_inheritable = cap_i.val;
+    proc.creds.cap_permitted = cap_p.val;
+
+    Ok(0)
+}
+
+fn try_capture(_ctx: BtfTracePointContext) -> Result<u32, u32> {
     let task = unsafe { bpf_get_current_task() as *const task_struct };
-    let pid =
-        unsafe { bpf_probe_read::<pid_t>(&(*task).tgid as *const _).map_err(|e| e as u32)? as u32 };
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let pid = (pid_tgid >> 32) as u32;
     let proc_ptr = unsafe { exec_map_get_init(pid) };
     let Some(proc_ptr) = proc_ptr else {
         return Err(0);
@@ -59,7 +93,7 @@ fn try_capture(_ctx: TracePointContext) -> Result<u32, u32> {
     // We need to read real executable name and get arguments from stack.
     let (arg_start, arg_end) = unsafe {
         proc.pid = pid;
-        proc.tid = bpf_probe_read::<pid_t>(&(*task).pid as *const _).map_err(|e| e as u32)? as u32;
+        proc.tid = pid_tgid as u32;
 
         let mm =
             bpf_probe_read::<*mut mm_struct>(&(*task).mm as *const *mut _).map_err(|e| e as u32)?;
@@ -68,17 +102,6 @@ fn try_capture(_ctx: TracePointContext) -> Result<u32, u32> {
 
         let arg_end = bpf_probe_read::<u64>(&(*mm).__bindgen_anon_1.arg_end as *const _)
             .map_err(|e| e as u32)?;
-        let file = bpf_probe_read::<*mut file>(&(*mm).__bindgen_anon_1.exe_file as *const *mut _)
-            .map_err(|e| e as u32)?;
-        let path = bpf_probe_read::<path>(&(*file).f_path as *const _).map_err(|e| e as u32)?;
-        let d_name =
-            bpf_probe_read::<qstr>(&(*(path.dentry)).d_name as *const _).map_err(|e| e as u32)?;
-        let inode = bpf_probe_read::<*mut inode>(&(*file).f_inode as *const *mut _)
-            .map_err(|e| e as u32)?;
-        let i_mode =
-            bpf_probe_read::<umode_t>(&(*inode).i_mode as *const _).map_err(|e| e as u32)?;
-
-        bpf_probe_read_kernel_str_bytes(d_name.name, &mut proc.filename).map_err(|e| e as u32)?;
 
         // Skip argv[0]
         let first_arg = bpf_probe_read_user_str_bytes(arg_start as *const u8, &mut proc.args)
@@ -86,19 +109,22 @@ fn try_capture(_ctx: TracePointContext) -> Result<u32, u32> {
 
         arg_start += 1 + first_arg.len() as u64;
 
+        let file = bpf_probe_read::<*mut file>(&(*mm).__bindgen_anon_1.exe_file as *const *mut _)
+            .map_err(|e| e as u32)?;
+        let path = bpf_probe_read::<path>(&(*file).f_path as *const _).map_err(|e| e as u32)?;
+
+        let d_name =
+            bpf_probe_read::<qstr>(&(*(path.dentry)).d_name as *const _).map_err(|e| e as u32)?;
+
+        bpf_probe_read_kernel_str_bytes(d_name.name, &mut proc.filename).map_err(|e| e as u32)?;
+
         // Get cred
-        let cred = bpf_probe_read::<*const cred>(&(*task).cred as *const *const _)
-            .map_err(|e| e as u32)?;
-        let euid = bpf_probe_read::<kuid_t>(&(*cred).euid as *const _).map_err(|e| e as u32)?;
-        let uid = bpf_probe_read::<kuid_t>(&(*cred).uid as *const _).map_err(|e| e as u32)?;
+        get_creds(proc, task)?;
 
-        proc.uid = uid.val;
-        proc.euid = euid.val;
-        let cap_e = bpf_probe_read::<kernel_cap_t>(&(*cred).cap_effective as *const _)
-            .map_err(|e| e as u32)?;
+        let loginuid =
+            bpf_probe_read::<kuid_t>(&(*task).loginuid as *const _).map_err(|e| e as u32)?;
 
-        proc.is_cap_set_uid = (cap_e.val & 128) != 0;
-        proc.is_suid = (i_mode & S_ISUID) != 0;
+        proc.auid = loginuid.val;
 
         (arg_start, arg_end)
     };
@@ -108,26 +134,92 @@ fn try_capture(_ctx: TracePointContext) -> Result<u32, u32> {
             .map_err(|e| e as u32)?;
     }
 
+    if let Some(cred_info) = CRED_SHARED_MAP.get_ptr(&pid_tgid) {
+        unsafe {
+            let Some(cred_info) = cred_info.as_ref() else {
+                return Err(0);
+            };
+            proc.creds.secureexec = cred_info.secureexec.clone();
+            bpf_probe_read_kernel_str_bytes(cred_info.binary_path.as_ptr(), &mut proc.binary_path)
+                .map_err(|e| e as u32)?;
+        }
+        CRED_SHARED_MAP.remove(&pid_tgid).unwrap();
+    }
+
     Ok(0)
 }
 
-#[kprobe]
-pub fn exit_capture(_ctx: ProbeContext) -> u32 {
+#[fentry]
+pub fn exit_capture(_ctx: FEntryContext) -> u32 {
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
     PROC_MAP.remove(&pid).unwrap();
     0
 }
 
-#[kprobe]
-pub fn fork_capture(ctx: ProbeContext) -> u32 {
+#[lsm]
+pub fn creds_capture(ctx: LsmContext) -> i32 {
+    match try_committing_creds(ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+fn try_committing_creds(ctx: LsmContext) -> Result<i32, i32> {
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let Some(cred_ptr) = CRED_HEAP.get_ptr_mut(0) else {
+        return Err(0);
+    };
+
+    let creds_info = unsafe { cred_ptr.as_mut() };
+
+    let Some(creds_info) = creds_info else {
+        return Err(0);
+    };
+    unsafe {
+        aya_ebpf::memset(cred_ptr as *mut u8, 0, core::mem::size_of_val(creds_info));
+        let binprm: *const linux_binprm = ctx.arg(0);
+
+        // Get cred
+        let cred = (*binprm).cred;
+        let euid = bpf_probe_read::<kuid_t>(&(*cred).euid as *const _)
+            .map_err(|e| e as i32)?
+            .val;
+        let uid = bpf_probe_read::<kuid_t>(&(*cred).uid as *const _)
+            .map_err(|e| e as i32)?
+            .val;
+        let egid = bpf_probe_read::<kgid_t>(&(*cred).egid as *const _)
+            .map_err(|e| e as i32)?
+            .val;
+        let gid = bpf_probe_read::<kgid_t>(&(*cred).gid as *const _)
+            .map_err(|e| e as i32)?
+            .val;
+        if euid != uid {
+            creds_info.secureexec |= SecureExec::SETUID;
+        }
+        if egid != gid {
+            creds_info.secureexec |= SecureExec::SETGID;
+        }
+        let file: *mut file = (*binprm).file;
+        let _ = bpf_d_path(
+            &(*file).f_path as *const _ as *mut aya_ebpf::bindings::path,
+            creds_info.binary_path.as_mut_ptr() as *mut i8,
+            creds_info.binary_path.len() as u32,
+        );
+        let _ = CRED_SHARED_MAP.insert(&pid_tgid, creds_info, BPF_ANY as u64);
+    }
+    Ok(0)
+}
+
+#[fentry]
+pub fn fork_capture(ctx: FEntryContext) -> u32 {
     match try_wake_up_new_task(ctx) {
         Ok(ret) => ret,
         Err(ret) => ret,
     }
 }
 
-fn try_wake_up_new_task(ctx: ProbeContext) -> Result<u32, u32> {
-    let task: *const task_struct = ctx.arg(0).ok_or(0u32)?;
+fn try_wake_up_new_task(ctx: FEntryContext) -> Result<u32, u32> {
+    let task: *const task_struct = unsafe { ctx.arg(0) };
     let tgid = unsafe { bpf_probe_read(&(*task).tgid as *const pid_t).map_err(|_| 0u32)? as u32 };
 
     let parent_proc = unsafe { execve_find_parent(task) };
@@ -150,10 +242,17 @@ fn try_wake_up_new_task(ctx: ProbeContext) -> Result<u32, u32> {
     unsafe {
         proc.ppid = (*parent_proc).pid;
         proc.ktime = bpf_ktime_get_ns();
+        proc.tid = bpf_probe_read::<pid_t>(&(*task).pid as *const _).map_err(|e| e as u32)? as u32;
         bpf_probe_read_kernel_str_bytes(&(*parent_proc).filename as *const _, &mut proc.filename)
             .map_err(|e| e as u32)?;
+        bpf_probe_read_kernel_str_bytes(
+            &(*parent_proc).binary_path as *const _,
+            &mut proc.binary_path,
+        )
+        .map_err(|e| e as u32)?;
         bpf_probe_read_kernel_buf(&(*parent_proc).args as *const _, &mut proc.args)
             .map_err(|e| e as u32)?;
+        get_creds(proc, task)?;
     }
     Ok(0)
 }

--- a/bombini/Cargo.toml
+++ b/bombini/Cargo.toml
@@ -10,6 +10,7 @@ aya-log = "0.2"
 bombini-common = { path = "../bombini-common", features = ["user"] }
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1"
+bitflags = { version = "2.8.0", features = ["serde"]}
 bytes = "1"
 env_logger = "0.10"
 lazy_static = "1.5"

--- a/bombini/src/detector/gtfobins.rs
+++ b/bombini/src/detector/gtfobins.rs
@@ -26,7 +26,7 @@ struct GTFOBinsConfig {
 
 impl Detector for GTFOBinsDetector {
     fn min_kenrel_verison(&self) -> Version {
-        Version::new(5, 8, 0)
+        Version::new(5, 10, 0)
     }
 
     async fn new<U: AsRef<Path>>(

--- a/bombini/src/transmuter/gtfobins.rs
+++ b/bombini/src/transmuter/gtfobins.rs
@@ -4,56 +4,21 @@ use bombini_common::event::gtfobins::GTFOBinsMsg;
 
 use serde::Serialize;
 
+use super::process::ProcessEvent;
+
 /// High-level event representation
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "type")]
 pub struct GTFOBinsEvent {
-    /// PID
-    pub pid: u32,
-    /// UID
-    pub uid: u32,
-    /// EUID
-    pub euid: u32,
-    /// if CAP_SET_UID is set in effective capabilities
-    pub is_cap_set_uid: bool,
-    /// if SETUID executable
-    pub is_suid: bool,
-    /// executable name
-    pub filename: String,
-    /// command line arguments without argv[0]
-    pub args: String,
+    /// Process Infro
+    process: ProcessEvent,
 }
 
 impl GTFOBinsEvent {
     /// Constructs High level event representation from low eBPF
     pub fn new(mut event: GTFOBinsMsg) -> Self {
-        let filename = if *event.process.filename.last().unwrap() == 0x0 {
-            let zero = event
-                .process
-                .filename
-                .iter()
-                .position(|e| *e == 0x0)
-                .unwrap();
-            String::from_utf8_lossy(&event.process.filename[..zero]).to_string()
-        } else {
-            String::from_utf8_lossy(&event.process.filename).to_string()
-        };
-        event.process.args.iter_mut().for_each(|e| {
-            if *e == 0x00 {
-                *e = 0x20
-            }
-        });
-        let args = String::from_utf8_lossy(&event.process.args)
-            .trim_end()
-            .to_string();
         Self {
-            pid: event.process.pid,
-            uid: event.process.uid,
-            euid: event.process.euid,
-            is_cap_set_uid: event.process.is_cap_set_uid,
-            is_suid: event.process.is_suid,
-            filename,
-            args,
+            process: ProcessEvent::new(&mut event.process),
         }
     }
 

--- a/bombini/src/transmuter/mod.rs
+++ b/bombini/src/transmuter/mod.rs
@@ -8,6 +8,7 @@ use histfile::HistFileEvent;
 
 mod gtfobins;
 mod histfile;
+mod process;
 
 /// Transmutes eBPF events from low representation into serialized formats
 pub struct Transmuter;

--- a/bombini/src/transmuter/process.rs
+++ b/bombini/src/transmuter/process.rs
@@ -1,0 +1,85 @@
+//! Transmutes Process to serializable struct
+
+use bombini_common::event::process::ProcInfo;
+
+use bitflags::bitflags;
+use serde::Serialize;
+
+/// High-level event representation
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type")]
+pub struct ProcessEvent {
+    /// PID
+    pub pid: u32,
+    /// TID
+    pub tid: u32,
+    /// Parent PID
+    pub ppid: u32,
+    /// UID
+    pub uid: u32,
+    /// EUID
+    pub euid: u32,
+    /// login UID
+    pub auid: u32,
+    pub cap_inheritable: u64,
+    pub cap_permitted: u64,
+    pub cap_effective: u64,
+    pub secureexec: SecureExec,
+    /// executable name
+    pub filename: String,
+    /// full binary path
+    pub binary_path: String,
+    /// current work directory
+    pub args: String,
+}
+
+bitflags! {
+    #[derive(Clone, Debug, Serialize)]
+    #[repr(C)]
+    pub struct SecureExec: u32 {
+        const SETUID = 0b00000001;
+        const SETGID = 0b00000010;
+        const FILE_CAPS = 0b00000100;
+    }
+}
+
+impl ProcessEvent {
+    /// Constructs High level event representation from low eBPF
+    pub fn new(proc: &mut ProcInfo) -> Self {
+        let filename = if *proc.filename.last().unwrap() == 0x0 {
+            let zero = proc.filename.iter().position(|e| *e == 0x0).unwrap();
+            String::from_utf8_lossy(&proc.filename[..zero]).to_string()
+        } else {
+            String::from_utf8_lossy(&proc.filename).to_string()
+        };
+
+        let binary_path = if *proc.binary_path.last().unwrap() == 0x0 {
+            let zero = proc.binary_path.iter().position(|e| *e == 0x0).unwrap();
+            String::from_utf8_lossy(&proc.binary_path[..zero]).to_string()
+        } else {
+            String::from_utf8_lossy(&proc.binary_path).to_string()
+        };
+
+        proc.args.iter_mut().for_each(|e| {
+            if *e == 0x00 {
+                *e = 0x20
+            }
+        });
+        let args = String::from_utf8_lossy(&proc.args).trim_end().to_string();
+        Self {
+            pid: proc.pid,
+            tid: proc.tid,
+            ppid: proc.ppid,
+            auid: proc.auid,
+            uid: proc.creds.uid,
+            euid: proc.creds.euid,
+            cap_effective: proc.creds.cap_effective,
+            cap_permitted: proc.creds.cap_permitted,
+            cap_inheritable: proc.creds.cap_inheritable,
+            secureexec: SecureExec::from_bits_truncate(proc.creds.secureexec.bits()),
+            filename,
+            binary_path,
+            args,
+        }
+    }
+}


### PR DESCRIPTION
Add ProcessEvent to summarize information about process in detector events. Use BPF_PROG_TRACING programs instead of kprobes, tracepoints. Use bpf_d_path to get full binary path in bprm_committing_creds hook.