### PR TITLE
feat: Filemon detector. File Access Monitoring Detector Using LSM Hooks   

### DIFF
--- a/bombini-common/src/config/filemon.rs
+++ b/bombini-common/src/config/filemon.rs
@@ -1,0 +1,23 @@
+//! Filemon config
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct Config {
+    pub file_open_config: HookConfig,
+    pub path_truncate_config: HookConfig,
+    pub path_unlink_config: HookConfig,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct HookConfig {
+    pub expose_events: bool,
+    pub disable: bool,
+}
+
+#[cfg(feature = "user")]
+pub mod user {
+    use super::*;
+
+    unsafe impl aya::Pod for Config {}
+}

--- a/bombini-common/src/config/mod.rs
+++ b/bombini-common/src/config/mod.rs
@@ -1,4 +1,5 @@
 //! Config module represents data structures to initialize detectors maps.
 
+pub mod filemon;
 pub mod gtfobins;
 pub mod procmon;

--- a/bombini-common/src/event/file.rs
+++ b/bombini-common/src/event/file.rs
@@ -1,0 +1,29 @@
+//! File event module
+
+use crate::event::process::{ProcInfo, MAX_FILENAME_SIZE, MAX_FILE_PATH};
+
+/// File open/mmap, etc. event
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct FileMsg {
+    pub process: ProcInfo,
+    pub hook: u8,
+    /// full path or full dir path for unlink
+    pub path: [u8; MAX_FILE_PATH],
+    /// file name
+    pub name: [u8; MAX_FILENAME_SIZE],
+    /// flags passed to open()
+    pub flags: u32,
+    /// File owner UID
+    pub uid: u32,
+    /// Group owner GID
+    pub gid: u32,
+    /// i_mode
+    pub i_mode: u16,
+}
+
+pub const HOOK_FILE_OPEN: u8 = 0;
+
+pub const HOOK_PATH_TRUNCATE: u8 = 1;
+
+pub const HOOK_PATH_UNLINK: u8 = 2;

--- a/bombini-common/src/event/mod.rs
+++ b/bombini-common/src/event/mod.rs
@@ -1,5 +1,6 @@
 //! Event module provide generic event message for all detectors
 
+pub mod file;
 pub mod process;
 
 /// Event messages
@@ -15,6 +16,7 @@ pub enum Event {
     /// 0 - 31 reserved for common events
     ProcExec(process::ProcInfo) = 0,
     ProcExit(process::ProcInfo) = 1,
+    File(file::FileMsg) = 2,
     /// GTFOBins execution event type
     GTFOBins(gtfobins::GTFOBinsMsg) = 32,
     /// Histfile modification event type
@@ -29,6 +31,8 @@ pub enum Event {
 pub const MSG_PROCEXEC: u8 = 0;
 /// ProcExit message code
 pub const MSG_PROCEXIT: u8 = 1;
+/// File message code
+pub const MSG_FILE: u8 = 2;
 /// GTFOBins execution message code
 pub const MSG_GTFOBINS: u8 = 32;
 /// HISTFILESIZE/HISTSIZE modification message code

--- a/bombini-detectors-ebpf/src/bin/filemon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/filemon/main.rs
@@ -39,6 +39,7 @@ pub fn file_open_capture(ctx: LsmContext) -> i32 {
     event_capture!(
         ctx,
         MSG_FILE,
+        false,
         try_open,
         config.file_open_config.expose_events
     ) as i32
@@ -96,6 +97,7 @@ pub fn path_truncate_capture(ctx: LsmContext) -> i32 {
     event_capture!(
         ctx,
         MSG_FILE,
+        true,
         try_truncate,
         config.path_truncate_config.expose_events
     ) as i32
@@ -140,6 +142,7 @@ pub fn path_unlink_capture(ctx: LsmContext) -> i32 {
     event_capture!(
         ctx,
         MSG_FILE,
+        false,
         try_unlink,
         config.path_unlink_config.expose_events
     ) as i32

--- a/bombini-detectors-ebpf/src/bin/filemon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/filemon/main.rs
@@ -1,0 +1,182 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{
+    helpers::{
+        bpf_d_path, bpf_get_current_pid_tgid, bpf_probe_read, bpf_probe_read_kernel_str_bytes,
+    },
+    macros::{lsm, map},
+    maps::{array::Array, hash_map::HashMap},
+    programs::LsmContext,
+};
+
+use bombini_common::config::filemon::Config;
+
+use bombini_common::event::file::{HOOK_FILE_OPEN, HOOK_PATH_TRUNCATE, HOOK_PATH_UNLINK};
+use bombini_common::event::process::{ProcInfo, MAX_FILENAME_SIZE};
+use bombini_common::event::{Event, MSG_FILE};
+use bombini_detectors_ebpf::vmlinux::{dentry, file, fmode_t, kgid_t, kuid_t, path, qstr};
+
+use bombini_detectors_ebpf::{event_capture, event_map::rb_event_init, util};
+
+#[map]
+static PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
+
+#[map]
+static FILE_CONFIG: Array<Config> = Array::with_max_entries(1, 0);
+
+const FMODE_EXEC: u32 = 1 << 5;
+
+#[lsm(hook = "file_open")]
+pub fn file_open_capture(ctx: LsmContext) -> i32 {
+    let Some(config_ptr) = FILE_CONFIG.get_ptr(0) else {
+        return 0;
+    };
+    let config = unsafe { config_ptr.as_ref() };
+    let Some(config) = config else {
+        return 0;
+    };
+    event_capture!(
+        ctx,
+        MSG_FILE,
+        try_open,
+        config.file_open_config.expose_events
+    ) as i32
+}
+
+fn try_open(ctx: LsmContext, event: &mut Event, expose: bool) -> Result<u32, u32> {
+    let Event::File(event) = event else {
+        return Err(0);
+    };
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let proc = unsafe { PROC_MAP.get(&pid) };
+    let Some(proc) = proc else {
+        return Err(0);
+    };
+    event.hook = HOOK_FILE_OPEN;
+    unsafe {
+        let fp: *const file = ctx.arg(0);
+        let fmode: fmode_t = (*fp).f_mode;
+        // Do not check opened files for execution. We have procmon for this
+        if fmode & FMODE_EXEC != 0 {
+            return Err(0);
+        }
+        let _ = bpf_d_path(
+            &(*fp).f_path as *const _ as *mut aya_ebpf::bindings::path,
+            event.path.as_mut_ptr() as *mut i8,
+            event.path.len() as u32,
+        );
+        event.flags = (*fp).f_flags;
+        event.i_mode = (*(*fp).f_inode).i_mode;
+        event.uid = bpf_probe_read::<kuid_t>(&(*(*fp).f_inode).i_uid as *const _)
+            .map_err(|_| 0u32)?
+            .val;
+        event.gid = bpf_probe_read::<kgid_t>(&(*(*fp).f_inode).i_gid as *const _)
+            .map_err(|_| 0u32)?
+            .val;
+    }
+
+    if expose {
+        util::copy_proc(proc, &mut event.process);
+        return Ok(0);
+    }
+
+    Err(0)
+}
+
+#[lsm(hook = "path_truncate")]
+pub fn path_truncate_capture(ctx: LsmContext) -> i32 {
+    let Some(config_ptr) = FILE_CONFIG.get_ptr(0) else {
+        return 0;
+    };
+    let config = unsafe { config_ptr.as_ref() };
+    let Some(config) = config else {
+        return 0;
+    };
+    event_capture!(
+        ctx,
+        MSG_FILE,
+        try_truncate,
+        config.path_truncate_config.expose_events
+    ) as i32
+}
+
+fn try_truncate(ctx: LsmContext, event: &mut Event, expose: bool) -> Result<u32, u32> {
+    let Event::File(event) = event else {
+        return Err(0);
+    };
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let proc = unsafe { PROC_MAP.get(&pid) };
+    let Some(proc) = proc else {
+        return Err(0);
+    };
+    event.hook = HOOK_PATH_TRUNCATE;
+    unsafe {
+        let p: *const path = ctx.arg(0);
+        let _ = bpf_d_path(
+            p as *const _ as *mut aya_ebpf::bindings::path,
+            event.path.as_mut_ptr() as *mut i8,
+            event.path.len() as u32,
+        );
+    }
+
+    if expose {
+        util::copy_proc(proc, &mut event.process);
+        return Ok(0);
+    }
+
+    Err(0)
+}
+
+#[lsm(hook = "path_unlink")]
+pub fn path_unlink_capture(ctx: LsmContext) -> i32 {
+    let Some(config_ptr) = FILE_CONFIG.get_ptr(0) else {
+        return 0;
+    };
+    let config = unsafe { config_ptr.as_ref() };
+    let Some(config) = config else {
+        return 0;
+    };
+    event_capture!(
+        ctx,
+        MSG_FILE,
+        try_unlink,
+        config.path_unlink_config.expose_events
+    ) as i32
+}
+
+fn try_unlink(ctx: LsmContext, event: &mut Event, expose: bool) -> Result<u32, u32> {
+    let Event::File(event) = event else {
+        return Err(0);
+    };
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let proc = unsafe { PROC_MAP.get(&pid) };
+    let Some(proc) = proc else {
+        return Err(0);
+    };
+    event.hook = HOOK_PATH_UNLINK;
+    unsafe {
+        let p: *const path = ctx.arg(0);
+        let entry: *const dentry = ctx.arg(1);
+        aya_ebpf::memset(event.process.filename.as_mut_ptr(), 0, MAX_FILENAME_SIZE);
+        let d_name = bpf_probe_read::<qstr>(&(*entry).d_name as *const _).map_err(|_| 0u32)?;
+        bpf_probe_read_kernel_str_bytes(d_name.name, &mut event.name).map_err(|_| 0u32)?;
+        let _ = bpf_d_path(
+            p as *const _ as *mut aya_ebpf::bindings::path,
+            event.path.as_mut_ptr() as *mut i8,
+            event.path.len() as u32,
+        );
+    }
+
+    if expose {
+        util::copy_proc(proc, &mut event.process);
+        return Ok(0);
+    }
+
+    Err(0)
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}

--- a/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
+++ b/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
@@ -30,7 +30,7 @@ static PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
 
 #[lsm]
 pub fn gtfobins_detect(ctx: LsmContext) -> i32 {
-    event_capture!(ctx, MSG_GTFOBINS, try_detect, true) as i32
+    event_capture!(ctx, MSG_GTFOBINS, true, try_detect, true) as i32
 }
 
 static MAX_PROC_DEPTH: u32 = 4;
@@ -50,7 +50,6 @@ fn try_detect(ctx: LsmContext, event: &mut Event, expose: bool) -> Result<u32, u
         // Check if sh is executing
         unsafe {
             let binprm: *const linux_binprm = ctx.arg(0);
-            aya_ebpf::memset(event.process.filename.as_mut_ptr(), 0, MAX_FILENAME_SIZE);
             let file: *mut file = (*binprm).file;
             let path = bpf_probe_read::<path>(&(*file).f_path as *const _).map_err(|_| 0_u32)?;
             let d_name =

--- a/bombini-detectors-ebpf/src/bin/histfile/main.rs
+++ b/bombini-detectors-ebpf/src/bin/histfile/main.rs
@@ -24,7 +24,7 @@ static PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
 
 #[uretprobe]
 pub fn histfile_detect(ctx: RetProbeContext) -> i32 {
-    event_capture!(ctx, MSG_HISTFILE, try_detect, true) as i32
+    event_capture!(ctx, MSG_HISTFILE, true, try_detect, true) as i32
 }
 
 fn try_detect(ctx: RetProbeContext, event: &mut Event, expose: bool) -> Result<u32, u32> {
@@ -38,7 +38,6 @@ fn try_detect(ctx: RetProbeContext, event: &mut Event, expose: bool) -> Result<u
     };
     let command: *const u8 = ctx.ret().ok_or(0u32)?;
     unsafe {
-        aya_ebpf::memset(event.command.as_mut_ptr(), 0, MAX_BASH_COMMAND_SIZE);
         bpf_probe_read_user_str_bytes(command, &mut event.command).map_err(|e| e as u32)?;
     }
     let lookup = Key::new((MAX_BASH_COMMAND_SIZE * 8) as u32, event.command);

--- a/bombini-detectors-ebpf/src/bin/io_uring/main.rs
+++ b/bombini-detectors-ebpf/src/bin/io_uring/main.rs
@@ -19,7 +19,7 @@ static PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
 
 #[btf_tracepoint(function = "io_uring_submit_req")]
 pub fn io_uring_submit_req_capture(ctx: BtfTracePointContext) -> u32 {
-    event_capture!(ctx, MSG_IOURING, try_submit_req, true)
+    event_capture!(ctx, MSG_IOURING, false, try_submit_req, true)
 }
 
 fn try_submit_req(ctx: BtfTracePointContext, event: &mut Event, expose: bool) -> Result<u32, u32> {

--- a/bombini-detectors-ebpf/src/bin/procmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/procmon/main.rs
@@ -84,7 +84,7 @@ pub fn execve_capture(ctx: BtfTracePointContext) -> u32 {
     let Some(config) = config else {
         return 0;
     };
-    event_capture!(ctx, MSG_PROCEXEC, try_execve, config.expose_events)
+    event_capture!(ctx, MSG_PROCEXEC, false, try_execve, config.expose_events)
 }
 
 fn try_execve(_ctx: BtfTracePointContext, event: &mut Event, expose: bool) -> Result<u32, u32> {
@@ -185,7 +185,7 @@ pub fn exit_capture(ctx: FEntryContext) -> u32 {
     let Some(config) = config else {
         return 0;
     };
-    event_capture!(ctx, MSG_PROCEXIT, try_exit, config.expose_events)
+    event_capture!(ctx, MSG_PROCEXIT, false, try_exit, config.expose_events)
 }
 
 fn try_exit(_ctx: FEntryContext, event: &mut Event, expose: bool) -> Result<u32, u32> {

--- a/bombini/src/detector/filemon.rs
+++ b/bombini/src/detector/filemon.rs
@@ -1,0 +1,121 @@
+//! File monitor detector
+
+use aya::maps::Array;
+use aya::programs::Lsm;
+use aya::{Btf, Ebpf, EbpfError};
+
+use procfs::sys::kernel::Version;
+use yaml_rust2::{Yaml, YamlLoader};
+
+use std::path::Path;
+
+use bombini_common::config::filemon::{Config, HookConfig};
+
+use super::{load_ebpf_obj, Detector};
+
+pub struct FileMon {
+    ebpf: Ebpf,
+    config: Option<Config>,
+}
+
+impl Detector for FileMon {
+    fn min_kenrel_verison(&self) -> Version {
+        Version::new(5, 11, 0)
+    }
+
+    async fn new<U: AsRef<Path>>(
+        obj_path: U,
+        config_path: Option<U>,
+    ) -> Result<Self, anyhow::Error> {
+        let ebpf = load_ebpf_obj(obj_path).await?;
+        if let Some(config_path) = config_path {
+            let mut config = Config {
+                file_open_config: HookConfig {
+                    expose_events: true,
+                    disable: false,
+                },
+                path_truncate_config: HookConfig {
+                    expose_events: true,
+                    disable: false,
+                },
+                path_unlink_config: HookConfig {
+                    expose_events: true,
+                    disable: false,
+                },
+            };
+
+            let s = std::fs::read_to_string(config_path.as_ref())?;
+            let docs = YamlLoader::load_from_str(&s)?;
+            let Some(doc) = docs[0].as_hash() else {
+                anyhow::bail!("filemon config must be a Hash")
+            };
+
+            if let Some(hook) = doc.get(&Yaml::from_str("file-open")) {
+                config.file_open_config.expose_events =
+                    hook["expose-events"].as_bool().unwrap_or(true);
+                config.file_open_config.disable = hook["disable"].as_bool().unwrap_or(false);
+            }
+
+            if let Some(hook) = doc.get(&Yaml::from_str("path-truncate")) {
+                config.path_truncate_config.expose_events =
+                    hook["expose-events"].as_bool().unwrap_or(true);
+                config.path_truncate_config.disable = hook["disable"].as_bool().unwrap_or(false);
+            }
+
+            if let Some(hook) = doc.get(&Yaml::from_str("path-truncate")) {
+                config.path_unlink_config.expose_events =
+                    hook["expose-events"].as_bool().unwrap_or(true);
+                config.path_unlink_config.disable = hook["disable"].as_bool().unwrap_or(false);
+            }
+
+            Ok(FileMon {
+                ebpf,
+                config: Some(config),
+            })
+        } else {
+            Ok(FileMon { ebpf, config: None })
+        }
+    }
+
+    fn map_initialize(&mut self) -> Result<(), EbpfError> {
+        if let Some(config) = self.config {
+            let mut config_map: Array<_, Config> =
+                Array::try_from(self.ebpf.map_mut("FILE_CONFIG").unwrap())?;
+            let _ = config_map.set(0, config, 0);
+        }
+        Ok(())
+    }
+
+    fn load_and_attach_programs(&mut self) -> Result<(), EbpfError> {
+        let btf = Btf::from_sys_fs()?;
+
+        if self.config.is_none() || !self.config.unwrap().file_open_config.disable {
+            let open: &mut Lsm = self
+                .ebpf
+                .program_mut("file_open_capture")
+                .unwrap()
+                .try_into()?;
+            open.load("file_open", &btf)?;
+            open.attach()?;
+        }
+        if self.config.is_none() || !self.config.unwrap().path_truncate_config.disable {
+            let truncate: &mut Lsm = self
+                .ebpf
+                .program_mut("path_truncate_capture")
+                .unwrap()
+                .try_into()?;
+            truncate.load("path_truncate", &btf)?;
+            truncate.attach()?;
+        }
+        if self.config.is_none() || !self.config.unwrap().path_unlink_config.disable {
+            let unlink: &mut Lsm = self
+                .ebpf
+                .program_mut("path_unlink_capture")
+                .unwrap()
+                .try_into()?;
+            unlink.load("path_unlink", &btf)?;
+            unlink.attach()?;
+        }
+        Ok(())
+    }
+}

--- a/bombini/src/detector/mod.rs
+++ b/bombini/src/detector/mod.rs
@@ -10,6 +10,7 @@ use anyhow::anyhow;
 
 use crate::config::{CONFIG, EVENT_MAP_NAME};
 
+pub mod filemon;
 pub mod gtfobins;
 pub mod histfile;
 pub mod io_uring;

--- a/bombini/src/registry.rs
+++ b/bombini/src/registry.rs
@@ -11,6 +11,7 @@ use crate::detector::gtfobins::GTFOBinsDetector;
 use crate::detector::histfile::HistFileDetector;
 use crate::detector::io_uring::IOUringDetector;
 
+use crate::detector::filemon::FileMon;
 use crate::detector::procmon::ProcMon;
 use crate::detector::Detector;
 
@@ -57,6 +58,11 @@ impl Registry {
                     let mut procmon = ProcMon::new(&obj_path, Some(&config_path)).await?;
                     procmon.load()?;
                     self.detectors.insert(name.to_string(), Box::new(procmon));
+                }
+                "filemon" => {
+                    let mut filemon = FileMon::new(&obj_path, Some(&config_path)).await?;
+                    filemon.load()?;
+                    self.detectors.insert(name.to_string(), Box::new(filemon));
                 }
                 _ => return Err(anyhow!("{} unknown detector", name)),
             };

--- a/bombini/src/transmuter/file.rs
+++ b/bombini/src/transmuter/file.rs
@@ -1,0 +1,238 @@
+//! Transmutes FileEvent to serialized format
+
+use bombini_common::event::file::{FileMsg, HOOK_FILE_OPEN, HOOK_PATH_TRUNCATE, HOOK_PATH_UNLINK};
+
+use bitflags::bitflags;
+use serde::{Serialize, Serializer};
+
+use super::process::Process;
+use super::Transmute;
+
+bitflags! {
+    #[derive(Clone, Debug, Serialize)]
+    #[repr(C)]
+    pub struct AccessMode: u32 {
+        const O_RDONLY =    0b00000001;
+        const O_WRONLY =    0b00000010;
+        const O_RDWR =      0b00000100;
+    }
+}
+
+bitflags! {
+    #[derive(Clone, Debug, Serialize)]
+    #[repr(C)]
+    pub struct CreationFlags: u32 {
+        const O_CREAT =	    0o00000100;
+        const O_EXCL =      0o00000200;
+        const O_NOCTTY =    0o00000400;
+        const O_TRUNC =	    0o00001000;
+        const O_APPEND =    0o00002000;
+        const O_NONBLOCK =  0o00004000;
+        const O_DSYNC =	    0o00010000;
+        const O_FASYNC =    0o00020000;
+        const O_DIRECT	=   0o00040000;
+        const O_LARGEFILE = 0o00100000;
+        const O_DIRECTORY =	0o00200000;
+        const O_NOFOLLOW =	0o00400000;
+        const O_NOATIME	=   0o01000000;
+        const O_CLOEXEC =   0o02000000;
+        const O_SYNC =	    0o04010000;
+        const O_PATH =		0o10000000;
+        const O_TMPFILE =   0o20200000;
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Imode(u16);
+
+// File type
+const S_IFMT: u16 = 0o170000;
+const S_IFSOCK: u16 = 0o140000;
+const S_IFLNK: u16 = 0o120000;
+const S_IFREG: u16 = 0o100000;
+const S_IFBLK: u16 = 0o060000;
+const S_IFDIR: u16 = 0o040000;
+const S_IFCHR: u16 = 0o020000;
+const S_IFIFO: u16 = 0o010000;
+
+// Access type
+const S_ISUID: u16 = 0o4000;
+const S_ISGID: u16 = 0o2000;
+const S_ISVTX: u16 = 0o1000;
+
+const S_IRUSR: u16 = 0o0400;
+const S_IWUSR: u16 = 0o0200;
+const S_IXUSR: u16 = 0o0100;
+
+const S_IRGRP: u16 = 0o0040;
+const S_IWGRP: u16 = 0o0020;
+const S_IXGRP: u16 = 0o0010;
+
+const S_IROTH: u16 = 0o0004;
+const S_IWOTH: u16 = 0o0002;
+const S_IXOTH: u16 = 0o0001;
+
+impl Serialize for Imode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut result = String::with_capacity(11);
+
+        // Get file type
+        let file_type = self.0 & S_IFMT;
+        let file_type_char = match file_type {
+            S_IFSOCK => 's',
+            S_IFLNK => 'l',
+            S_IFREG => '-',
+            S_IFBLK => 'b',
+            S_IFDIR => 'd',
+            S_IFCHR => 'c',
+            S_IFIFO => 'p',
+            _ => '?',
+        };
+        result.push(file_type_char);
+
+        // Access for owner
+        result.push(if (self.0 & S_IRUSR) != 0 { 'r' } else { '-' });
+        result.push(if (self.0 & S_IWUSR) != 0 { 'w' } else { '-' });
+
+        let mut x = if (self.0 & S_IXUSR) != 0 { 'x' } else { '-' };
+        if (self.0 & S_ISUID) != 0 {
+            x = if x == 'x' { 's' } else { 'S' };
+        }
+        result.push(x);
+
+        // Access for group
+        result.push(if (self.0 & S_IRGRP) != 0 { 'r' } else { '-' });
+        result.push(if (self.0 & S_IWGRP) != 0 { 'w' } else { '-' });
+
+        x = if (self.0 & S_IXGRP) != 0 { 'x' } else { '-' };
+        if (self.0 & S_ISGID) != 0 {
+            x = if x == 'x' { 's' } else { 'S' };
+        }
+        result.push(x);
+
+        // Access for others
+        result.push(if (self.0 & S_IROTH) != 0 { 'r' } else { '-' });
+        result.push(if (self.0 & S_IWOTH) != 0 { 'w' } else { '-' });
+
+        x = if (self.0 & S_IXOTH) != 0 { 'x' } else { '-' };
+        if (self.0 & S_ISVTX) != 0 {
+            x = if x == 'x' { 't' } else { 'T' };
+        }
+        result.push(x);
+
+        serializer.serialize_str(&result)
+    }
+}
+
+impl From<u16> for Imode {
+    fn from(value: u16) -> Self {
+        Imode(value)
+    }
+}
+
+/// High-level event representation
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type")]
+pub struct FileEvent {
+    /// Process Infro
+    process: Process,
+    /// LSM File hook info
+    hook: LsmFileHook,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FileOpenInfo {
+    /// full path
+    path: String,
+    /// access mode passed to open()
+    access_mode: AccessMode,
+    /// creation flags passed to open()
+    creation_flags: CreationFlags,
+    /// File owner UID
+    uid: u32,
+    /// Group owner GID
+    gid: u32,
+    /// i_mode
+    i_mode: Imode,
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct PathTruncateInfo {
+    /// full path
+    path: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PathUnlinkInfo {
+    /// full directory path
+    dir: String,
+    /// file name
+    filename: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type")]
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum LsmFileHook {
+    FileOpen(FileOpenInfo),
+    PathTruncate(PathTruncateInfo),
+    PathUnlink(PathUnlinkInfo),
+}
+
+impl FileEvent {
+    /// Constructs High level event representation from low eBPF message
+    pub fn new(event: FileMsg) -> Self {
+        match event.hook {
+            HOOK_FILE_OPEN => {
+                let info = FileOpenInfo {
+                    path: str_from_bytes(&event.path),
+                    access_mode: AccessMode::from_bits_truncate(1 << (event.flags & 3)),
+                    creation_flags: CreationFlags::from_bits_truncate(event.flags),
+                    uid: event.uid,
+                    gid: event.gid,
+                    i_mode: event.i_mode.into(),
+                };
+                Self {
+                    process: Process::new(event.process),
+                    hook: LsmFileHook::FileOpen(info),
+                }
+            }
+            HOOK_PATH_TRUNCATE => {
+                let info = PathTruncateInfo {
+                    path: str_from_bytes(&event.path),
+                };
+                Self {
+                    process: Process::new(event.process),
+                    hook: LsmFileHook::PathTruncate(info),
+                }
+            }
+            HOOK_PATH_UNLINK => {
+                let info = PathUnlinkInfo {
+                    dir: str_from_bytes(&event.path),
+                    filename: str_from_bytes(&event.name),
+                };
+                Self {
+                    process: Process::new(event.process),
+                    hook: LsmFileHook::PathUnlink(info),
+                }
+            }
+            _ => {
+                panic!("unsupported LSM BPF File hook");
+            }
+        }
+    }
+}
+
+fn str_from_bytes(bytes: &[u8]) -> String {
+    if *bytes.last().unwrap() == 0x0 {
+        let zero = bytes.iter().position(|e| *e == 0x0).unwrap();
+        String::from_utf8_lossy(&bytes[..zero]).to_string()
+    } else {
+        String::from_utf8_lossy(bytes).to_string()
+    }
+}
+
+impl Transmute for FileEvent {}

--- a/bombini/src/transmuter/mod.rs
+++ b/bombini/src/transmuter/mod.rs
@@ -3,6 +3,7 @@
 
 use bombini_common::event::Event;
 
+use file::FileEvent;
 use gtfobins::GTFOBinsEvent;
 use histfile::HistFileEvent;
 use io_uring::IOUringEvent;
@@ -10,6 +11,7 @@ use process::ProcessExec;
 use process::ProcessExit;
 use serde::Serialize;
 
+mod file;
 mod gtfobins;
 mod histfile;
 mod io_uring;
@@ -24,6 +26,7 @@ impl Transmuter {
         match event {
             Event::ProcExec(s) => Ok(ProcessExec::new(s).to_json()?.into_bytes()),
             Event::ProcExit(s) => Ok(ProcessExit::new(s).to_json()?.into_bytes()),
+            Event::File(s) => Ok(FileEvent::new(s).to_json()?.into_bytes()),
             Event::GTFOBins(s) => Ok(GTFOBinsEvent::new(s).to_json()?.into_bytes()),
             Event::HistFile(s) => Ok(HistFileEvent::new(s).to_json()?.into_bytes()),
             Event::IOUring(s) => Ok(IOUringEvent::new(s).to_json()?.into_bytes()),

--- a/bombini/tests/tests.rs
+++ b/bombini/tests/tests.rs
@@ -53,7 +53,7 @@ fn test_detectors_load() {
     }
     let mut bombini = bombini.expect("failed to start bombini");
     // Wait for detectors being loaded
-    thread::sleep(Duration::from_millis(1500));
+    thread::sleep(Duration::from_millis(3000));
 
     let _ = signal::kill(Pid::from_raw(bombini.id() as i32), Signal::SIGINT);
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,7 @@ event_channel_size: 64
 # List of the detectors to load
 detectors:
    - procmon
+   - filemon
    - gtfobins
    - histfile
    - io_uring

--- a/config/filemon.yaml
+++ b/config/filemon.yaml
@@ -1,0 +1,6 @@
+file-open:
+  disable: true
+path-truncate:
+  expose-events: true
+path-unlink:
+  expose-events: true

--- a/docs/design.md
+++ b/docs/design.md
@@ -69,3 +69,11 @@ It provides events with the following information:
 * process information
 
 Inspired by this [example](https://github.com/armosec/curing) and [post](https://www.armosec.io/blog/io_uring-rootkit-bypasses-linux-security/).
+
+## FileMon
+
+Detector for file operations. Each event has process information. Supported hooks:
+
+* `security_file_open` hook  provides info about file owner/permissions + permissions with process accessed the file.
+* `path_truncate` hook provides info about path truncated by truncate syscall.
+* `path_unlink` provides info about path being deleted.


### PR DESCRIPTION
This PR introduces Filemon , a new detector module that tracks file access events using Linux Security Module (LSM) hooks. It provides detailed visibility into file operations across the system.

Detector implements tracking of file access events via these LSM hooks:   
-     security_file_open (file open operations)  
-     security_path_unlink (file delete operations)  
-     security_path_truncate (file truncation)

**Each event includes:**
-     Process context  
-     Access mode : Read/write/execute/truncate flags  
-     File metadata : Path, owner (UID/GID), permissions (i_mode)

**Future Improvements:**  
-     Filtering : Add whitelist-based exclusion (e.g., ignore specific processes/files)  
     