### PR TITLE
refactor: rename all bpf maps

### DIFF
--- a/bombini-detectors-ebpf/src/bin/io_uring/main.rs
+++ b/bombini-detectors-ebpf/src/bin/io_uring/main.rs
@@ -15,7 +15,7 @@ use bombini_detectors_ebpf::vmlinux::io_kiocb;
 use bombini_detectors_ebpf::{event_capture, event_map::rb_event_init, util};
 
 #[map]
-static PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
+static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
 
 #[btf_tracepoint(function = "io_uring_submit_req")]
 pub fn io_uring_submit_req_capture(ctx: BtfTracePointContext) -> u32 {
@@ -27,7 +27,7 @@ fn try_submit_req(ctx: BtfTracePointContext, event: &mut Event, expose: bool) ->
         return Err(0);
     };
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-    let proc = unsafe { PROC_MAP.get(&pid) };
+    let proc = unsafe { PROCMON_PROC_MAP.get(&pid) };
     let Some(proc) = proc else {
         return Err(0);
     };

--- a/bombini/src/detector/filemon.rs
+++ b/bombini/src/detector/filemon.rs
@@ -80,7 +80,7 @@ impl Detector for FileMon {
     fn map_initialize(&mut self) -> Result<(), EbpfError> {
         if let Some(config) = self.config {
             let mut config_map: Array<_, Config> =
-                Array::try_from(self.ebpf.map_mut("FILE_CONFIG").unwrap())?;
+                Array::try_from(self.ebpf.map_mut("FILEMON_CONFIG").unwrap())?;
             let _ = config_map.set(0, config, 0);
         }
         Ok(())

--- a/bombini/src/detector/gtfobins.rs
+++ b/bombini/src/detector/gtfobins.rs
@@ -91,7 +91,7 @@ impl Detector for GTFOBinsDetector {
     fn map_initialize(&mut self) -> Result<(), EbpfError> {
         if let Some(config) = &self.config {
             let mut file_names: LpmTrie<_, GTFOBinsKey, u32> =
-                LpmTrie::try_from(self.ebpf.map_mut("GTFOBINS").unwrap())?;
+                LpmTrie::try_from(self.ebpf.map_mut("GTFOBINS_NAME_MAP").unwrap())?;
             for (k, v) in config.gtfobins_entries.iter() {
                 let key = Key::new((MAX_FILENAME_SIZE * 8) as u32, *k);
                 file_names.insert(&key, v, 0)?;

--- a/bombini/src/detector/histfile.rs
+++ b/bombini/src/detector/histfile.rs
@@ -39,7 +39,7 @@ impl Detector for HistFileDetector {
         let hist_fsz_key = Key::new((hist_fsz_str.len() * 8) as u32, hist_fsz_buf);
         let hist_sz_key = Key::new((hist_sz_str.len() * 8) as u32, hist_sz_buf);
         let mut hist_cmds: LpmTrie<_, [u8; MAX_BASH_COMMAND_SIZE], u32> =
-            LpmTrie::try_from(self.ebpf.map_mut("HIST_CHECK_MAP").unwrap())?;
+            LpmTrie::try_from(self.ebpf.map_mut("HISTFILE_CHECK_MAP").unwrap())?;
         hist_cmds.insert(&hist_fsz_key, 1, 0)?;
         hist_cmds.insert(&hist_sz_key, 1, 0)?;
         Ok(())

--- a/bombini/src/detector/procmon.rs
+++ b/bombini/src/detector/procmon.rs
@@ -52,7 +52,7 @@ impl Detector for ProcMon {
     fn map_initialize(&mut self) -> Result<(), EbpfError> {
         if let Some(config) = self.config {
             let mut config_map: Array<_, Config> =
-                Array::try_from(self.ebpf.map_mut("PROC_CONFIG").unwrap())?;
+                Array::try_from(self.ebpf.map_mut("PROCMON_CONFIG").unwrap())?;
             let _ = config_map.set(0, config, 0);
         }
         Ok(())


### PR DESCRIPTION
Let's name all bpf maps in the following way:

<DETECTOR_NAME>_CONFIG - config map for the detector 
<DETECTOR_NAME>_HEAP - maps as heap
<DETECTOR_NAME>_<MAP_NAME>_MAP - all other maps