### PR TITLE
feat: put PROCMON_PROC_MAP size in global config

### DIFF
--- a/bombini-detectors-ebpf/src/bin/filemon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/filemon/main.rs
@@ -20,7 +20,7 @@ use bombini_detectors_ebpf::vmlinux::{dentry, file, fmode_t, kgid_t, kuid_t, pat
 use bombini_detectors_ebpf::{event_capture, event_map::rb_event_init, util};
 
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
+static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
 
 #[map]
 static FILEMON_CONFIG: Array<Config> = Array::with_max_entries(1, 0);

--- a/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
+++ b/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
@@ -26,7 +26,7 @@ use bombini_detectors_ebpf::{event_capture, event_map::rb_event_init, util};
 static GTFOBINS_NAME_MAP: LpmTrie<GTFOBinsKey, u32> = LpmTrie::with_max_entries(128, 0);
 
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
+static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
 
 #[lsm]
 pub fn gtfobins_detect(ctx: LsmContext) -> i32 {

--- a/bombini-detectors-ebpf/src/bin/histfile/main.rs
+++ b/bombini-detectors-ebpf/src/bin/histfile/main.rs
@@ -21,7 +21,7 @@ static HISTFILE_CHECK_MAP: LpmTrie<[u8; MAX_BASH_COMMAND_SIZE], u32> =
     LpmTrie::with_max_entries(2, 0);
 
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
+static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
 
 #[uretprobe]
 pub fn histfile_detect(ctx: RetProbeContext) -> i32 {

--- a/bombini-detectors-ebpf/src/bin/io_uring/main.rs
+++ b/bombini-detectors-ebpf/src/bin/io_uring/main.rs
@@ -15,7 +15,7 @@ use bombini_detectors_ebpf::vmlinux::io_kiocb;
 use bombini_detectors_ebpf::{event_capture, event_map::rb_event_init, util};
 
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1024, 0);
+static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
 
 #[btf_tracepoint(function = "io_uring_submit_req")]
 pub fn io_uring_submit_req_capture(ctx: BtfTracePointContext) -> u32 {

--- a/bombini-detectors-ebpf/src/bin/procmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/procmon/main.rs
@@ -33,7 +33,7 @@ struct CredSharedInfo {
 
 /// Holds current live processes
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(8192, 0);
+static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
 
 /// Holds process information gathered on bprm_commiting_creds
 #[map]

--- a/bombini/src/config.rs
+++ b/bombini/src/config.rs
@@ -8,8 +8,11 @@ use tokio::sync::RwLock;
 
 use std::path::PathBuf;
 
-/// Ring buffer map name used to send events
+/// Ring buffer map name is used to send events
 pub const EVENT_MAP_NAME: &str = "EVENT_MAP";
+
+/// Procmon map name is used to hold alive processes
+pub const PROCMON_PROC_MAP_NAME: &str = "PROCMON_PROC_MAP";
 
 // Config holds options for cli interface and global agent parameters
 #[derive(Default, Clone, Debug, Parser)]
@@ -25,12 +28,19 @@ pub struct Config {
     pub maps_pin_path: Option<String>,
 
     /// Event map size (ring buffer size in bytes)
+    /// default value: 65536
     #[arg(long, value_name = "VALUE")]
     pub event_map_size: Option<u32>,
 
     /// Raw event channel size (number of event messages)
+    /// default value: 64
     #[arg(long, value_name = "VALUE")]
     pub event_channel_size: Option<usize>,
+
+    /// Procmon process map size
+    /// default value: 8192
+    #[arg(long, value_name = "VALUE")]
+    pub procmon_proc_map_size: Option<u32>,
 
     /// Detector to load. Can be specified multiple times.
     /// Overrides the config.
@@ -109,10 +119,20 @@ impl Config {
 
         if let Some(v) = doc["event_map_size"].as_i64() {
             self.event_map_size = Some(v as u32);
+        } else {
+            self.event_map_size = Some(65536);
         }
 
         if let Some(v) = doc["event_channel_size"].as_i64() {
             self.event_channel_size = Some(v as usize);
+        } else {
+            self.event_channel_size = Some(64);
+        }
+
+        if let Some(v) = doc["procmon_proc_map_size"].as_i64() {
+            self.procmon_proc_map_size = Some(v as u32);
+        } else {
+            self.procmon_proc_map_size = Some(8192);
         }
 
         if let Some(detectors) = doc["detectors"].as_vec() {
@@ -137,6 +157,9 @@ impl Config {
         }
         if let Some(v) = args.event_channel_size {
             self.event_channel_size = Some(v);
+        }
+        if let Some(v) = args.procmon_proc_map_size {
+            self.procmon_proc_map_size = Some(v);
         }
         if let Some(detectors) = args.detectors {
             self.detectors = Some(detectors.to_vec());

--- a/bombini/src/detector/mod.rs
+++ b/bombini/src/detector/mod.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use anyhow::anyhow;
 
-use crate::config::{CONFIG, EVENT_MAP_NAME};
+use crate::config::{CONFIG, EVENT_MAP_NAME, PROCMON_PROC_MAP_NAME};
 
 pub mod filemon;
 pub mod gtfobins;
@@ -70,5 +70,6 @@ pub async fn load_ebpf_obj<U: AsRef<Path>>(obj_path: U) -> Result<Ebpf, EbpfErro
     EbpfLoader::new()
         .map_pin_path(config.maps_pin_path.as_ref().unwrap())
         .set_max_entries(EVENT_MAP_NAME, config.event_map_size.unwrap())
+        .set_max_entries(PROCMON_PROC_MAP_NAME, config.procmon_proc_map_size.unwrap())
         .load_file(obj_path.as_ref())
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,6 +14,9 @@ event_map_size: 65536
 # Raw event channel size (number of event messages)
 event_channel_size: 64
 
+# Procmon process map size
+procmon_proc_map_size: 8192
+
 # List of the detectors to load
 detectors:
    - procmon


### PR DESCRIPTION
PROCMON_PROC_MAP holds information about alive processes. This map is used by all detectors. Let's for simplicity control the size of this map from global for now.