### PR TITLE
Netmon

### DIFF
--- a/bombini-common/src/config/mod.rs
+++ b/bombini-common/src/config/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod filemon;
 pub mod gtfobins;
+pub mod network;
 pub mod procmon;

--- a/bombini-common/src/config/network.rs
+++ b/bombini-common/src/config/network.rs
@@ -1,0 +1,14 @@
+//! Networkmon config
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct Config {
+    pub expose_events: bool,
+}
+
+#[cfg(feature = "user")]
+pub mod user {
+    use super::*;
+
+    unsafe impl aya::Pod for Config {}
+}

--- a/bombini-common/src/event/mod.rs
+++ b/bombini-common/src/event/mod.rs
@@ -1,6 +1,7 @@
 //! Event module provide generic event message for all detectors
 
 pub mod file;
+pub mod network;
 pub mod process;
 
 /// Event messages
@@ -11,12 +12,13 @@ pub mod io_uring;
 /// Generic event for ring buffer
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
-#[repr(C, u8)]
+#[repr(u8)]
 pub enum Event {
     /// 0 - 31 reserved for common events
     ProcExec(process::ProcInfo) = 0,
     ProcExit(process::ProcInfo) = 1,
     File(file::FileMsg) = 2,
+    Network(network::NetworkMsg) = 3,
     /// GTFOBins execution event type
     GTFOBins(gtfobins::GTFOBinsMsg) = 32,
     /// Histfile modification event type
@@ -33,6 +35,8 @@ pub const MSG_PROCEXEC: u8 = 0;
 pub const MSG_PROCEXIT: u8 = 1;
 /// File message code
 pub const MSG_FILE: u8 = 2;
+/// Network message code
+pub const MSG_NETWORK: u8 = 3;
 /// GTFOBins execution message code
 pub const MSG_GTFOBINS: u8 = 32;
 /// HISTFILESIZE/HISTSIZE modification message code

--- a/bombini-common/src/event/network.rs
+++ b/bombini-common/src/event/network.rs
@@ -15,6 +15,8 @@ pub struct TcpConnectionV4 {
     pub sport: u16,
     /// destination port
     pub dport: u16,
+    /// socket cookie
+    pub cookie: u64,
 }
 
 /// TCP IPv6 connection information
@@ -30,6 +32,8 @@ pub struct TcpConnectionV6 {
     pub sport: u16,
     /// destination port
     pub dport: u16,
+    /// socket cookie
+    pub cookie: u64,
 }
 
 /// Raw network event messages
@@ -41,4 +45,8 @@ pub enum NetworkMsg {
     TcpConV4Establish(TcpConnectionV4) = 0,
     /// Establishing TCP connection for IPv6
     TcpConV6Establish(TcpConnectionV6) = 1,
+    /// Closing TCP connection for IPv4
+    TcpConV4Close(TcpConnectionV4) = 2,
+    /// Closing TCP connection for IPv6
+    TcpConV6Close(TcpConnectionV6) = 3,
 }

--- a/bombini-common/src/event/network.rs
+++ b/bombini-common/src/event/network.rs
@@ -49,4 +49,8 @@ pub enum NetworkMsg {
     TcpConV4Close(TcpConnectionV4) = 2,
     /// Closing TCP connection for IPv6
     TcpConV6Close(TcpConnectionV6) = 3,
+    /// Accepting TCP connection for IPv4
+    TcpConV4Accept(TcpConnectionV4) = 4,
+    /// Accepting TCP connection for IPv6
+    TcpConV6Accept(TcpConnectionV6) = 5,
 }

--- a/bombini-common/src/event/network.rs
+++ b/bombini-common/src/event/network.rs
@@ -1,0 +1,44 @@
+//! Network event module
+
+use crate::event::process::ProcInfo;
+
+/// TCP IPv4 connection information
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct TcpConnectionV4 {
+    pub process: ProcInfo,
+    /// source IP address
+    pub saddr: u32,
+    /// destination IP address,
+    pub daddr: u32,
+    /// source port
+    pub sport: u16,
+    /// destination port
+    pub dport: u16,
+}
+
+/// TCP IPv6 connection information
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct TcpConnectionV6 {
+    pub process: ProcInfo,
+    /// source IP address
+    pub saddr: [u8; 16],
+    /// destination IP address,
+    pub daddr: [u8; 16],
+    /// source port
+    pub sport: u16,
+    /// destination port
+    pub dport: u16,
+}
+
+/// Raw network event messages
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+#[repr(u8)]
+pub enum NetworkMsg {
+    /// Establishing TCP connection for IPv4
+    TcpConV4Establish(TcpConnectionV4) = 0,
+    /// Establishing TCP connection for IPv6
+    TcpConV6Establish(TcpConnectionV6) = 1,
+}

--- a/bombini-detectors-ebpf/src/bin/netmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/netmon/main.rs
@@ -1,0 +1,153 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{
+    helpers::bpf_probe_read_kernel_buf,
+    macros::{fexit, map},
+    maps::{array::Array, hash_map::HashMap},
+    programs::FExitContext,
+    EbpfContext,
+};
+
+use bombini_detectors_ebpf::vmlinux::sock;
+
+use bombini_common::event::process::ProcInfo;
+use bombini_common::event::{Event, MSG_NETWORK};
+use bombini_common::{config::network::Config, event::network::NetworkMsg};
+
+use bombini_detectors_ebpf::{event_capture, event_map::rb_event_init, util};
+
+/// Holds current alive processes
+#[map]
+static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
+
+#[map]
+static NETMON_CONFIG: Array<Config> = Array::with_max_entries(1, 0);
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}
+
+#[fexit(function = "tcp_v4_connect")]
+pub fn tcp_v4_connect_capture(ctx: FExitContext) -> u32 {
+    let Some(config_ptr) = NETMON_CONFIG.get_ptr(0) else {
+        return 0;
+    };
+    let config = unsafe { config_ptr.as_ref() };
+    let Some(config) = config else {
+        return 0;
+    };
+    event_capture!(
+        ctx,
+        MSG_NETWORK,
+        false,
+        try_tcp_v4_connect,
+        config.expose_events
+    )
+}
+
+fn try_tcp_v4_connect(ctx: FExitContext, event: &mut Event, expose: bool) -> Result<u32, u32> {
+    let Event::Network(event) = event else {
+        return Err(0);
+    };
+    let pid = ctx.pid();
+    let proc = unsafe { PROCMON_PROC_MAP.get(&pid) };
+    let Some(proc) = proc else {
+        return Err(0);
+    };
+
+    unsafe {
+        let p = event as *mut NetworkMsg as *mut u8;
+        // TcpConV4Established
+        *p = 0;
+    }
+
+    let NetworkMsg::TcpConV4Establish(event) = event else {
+        return Err(0);
+    };
+
+    unsafe {
+        let s = ctx.arg::<*const sock>(0);
+        let skaddr_pair = (*s).__sk_common.__bindgen_anon_1.skc_addrpair;
+        let skport_pair = (*s).__sk_common.__bindgen_anon_3.skc_portpair;
+        event.saddr = (skaddr_pair >> 32) as u32;
+        event.daddr = skaddr_pair as u32;
+        event.sport = (skport_pair >> 16) as u16;
+        event.dport = skport_pair as u16;
+        event.dport = event.dport.rotate_left(8);
+    }
+    if event.saddr == 0 || event.daddr == 0 || event.sport == 0 || event.dport == 0 {
+        return Err(0);
+    }
+
+    if expose {
+        util::copy_proc(proc, &mut event.process);
+    }
+    Ok(0)
+}
+
+#[fexit(function = "tcp_v6_connect")]
+pub fn tcp_v6_connect_capture(ctx: FExitContext) -> u32 {
+    let Some(config_ptr) = NETMON_CONFIG.get_ptr(0) else {
+        return 0;
+    };
+    let config = unsafe { config_ptr.as_ref() };
+    let Some(config) = config else {
+        return 0;
+    };
+    event_capture!(
+        ctx,
+        MSG_NETWORK,
+        false,
+        try_tcp_v6_connect,
+        config.expose_events
+    )
+}
+
+fn try_tcp_v6_connect(ctx: FExitContext, event: &mut Event, expose: bool) -> Result<u32, u32> {
+    let Event::Network(event) = event else {
+        return Err(0);
+    };
+    let pid = ctx.pid();
+    let proc = unsafe { PROCMON_PROC_MAP.get(&pid) };
+    let Some(proc) = proc else {
+        return Err(0);
+    };
+
+    unsafe {
+        let p = event as *mut NetworkMsg as *mut u8;
+        // TcpConV6Established
+        *p = 1;
+    }
+
+    let NetworkMsg::TcpConV6Establish(event) = event else {
+        return Err(0);
+    };
+
+    unsafe {
+        let s = ctx.arg::<*const sock>(0);
+        let skport_pair = (*s).__sk_common.__bindgen_anon_3.skc_portpair;
+        bpf_probe_read_kernel_buf(
+            &(*s).__sk_common.skc_v6_daddr.in6_u.u6_addr8 as *const _,
+            &mut event.daddr,
+        )
+        .map_err(|_| 0u32)?;
+        bpf_probe_read_kernel_buf(
+            &(*s).__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 as *const _,
+            &mut event.saddr,
+        )
+        .map_err(|_| 0u32)?;
+        event.sport = (skport_pair >> 16) as u16;
+        event.dport = skport_pair as u16;
+        event.dport = event.dport.rotate_left(8);
+    }
+    if event.sport == 0 || event.dport == 0 {
+        return Err(0);
+    }
+
+    if expose {
+        util::copy_proc(proc, &mut event.process);
+    }
+    Ok(0)
+}

--- a/bombini-detectors-ebpf/src/bin/netmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/netmon/main.rs
@@ -2,7 +2,8 @@
 #![no_main]
 
 use aya_ebpf::{
-    helpers::bpf_probe_read_kernel_buf,
+    cty::c_void,
+    helpers::{bpf_get_socket_cookie, bpf_probe_read_kernel_buf},
     macros::{fexit, map},
     maps::{array::Array, hash_map::HashMap},
     programs::FExitContext,
@@ -11,7 +12,9 @@ use aya_ebpf::{
 
 use bombini_detectors_ebpf::vmlinux::sock;
 
-use bombini_common::event::process::ProcInfo;
+use bombini_common::event::{
+    network::TcpConnectionV4, network::TcpConnectionV6, process::ProcInfo,
+};
 use bombini_common::event::{Event, MSG_NETWORK};
 use bombini_common::{config::network::Config, event::network::NetworkMsg};
 
@@ -27,6 +30,40 @@ static NETMON_CONFIG: Array<Config> = Array::with_max_entries(1, 0);
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe { core::hint::unreachable_unchecked() }
+}
+
+const AF_INET6: u16 = 10;
+
+const AF_INET: u16 = 2;
+
+unsafe fn parse_v4_sock(event: &mut TcpConnectionV4, s: *const sock) {
+    let skaddr_pair = (*s).__sk_common.__bindgen_anon_1.skc_addrpair;
+    let skport_pair = (*s).__sk_common.__bindgen_anon_3.skc_portpair;
+    event.saddr = (skaddr_pair >> 32) as u32;
+    event.daddr = skaddr_pair as u32;
+    event.sport = (skport_pair >> 16) as u16;
+    event.dport = skport_pair as u16;
+    event.dport = event.dport.rotate_left(8);
+    event.cookie = bpf_get_socket_cookie(s as *mut sock as *mut c_void);
+}
+
+unsafe fn parse_v6_sock(event: &mut TcpConnectionV6, s: *const sock) -> Result<(), u32> {
+    let skport_pair = (*s).__sk_common.__bindgen_anon_3.skc_portpair;
+    bpf_probe_read_kernel_buf(
+        &(*s).__sk_common.skc_v6_daddr.in6_u.u6_addr8 as *const _,
+        &mut event.daddr,
+    )
+    .map_err(|_| 0u32)?;
+    bpf_probe_read_kernel_buf(
+        &(*s).__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 as *const _,
+        &mut event.saddr,
+    )
+    .map_err(|_| 0u32)?;
+    event.sport = (skport_pair >> 16) as u16;
+    event.dport = skport_pair as u16;
+    event.dport = event.dport.rotate_left(8);
+    event.cookie = bpf_get_socket_cookie(s as *mut sock as *mut c_void);
+    Ok(())
 }
 
 #[fexit(function = "tcp_v4_connect")]
@@ -69,13 +106,7 @@ fn try_tcp_v4_connect(ctx: FExitContext, event: &mut Event, expose: bool) -> Res
 
     unsafe {
         let s = ctx.arg::<*const sock>(0);
-        let skaddr_pair = (*s).__sk_common.__bindgen_anon_1.skc_addrpair;
-        let skport_pair = (*s).__sk_common.__bindgen_anon_3.skc_portpair;
-        event.saddr = (skaddr_pair >> 32) as u32;
-        event.daddr = skaddr_pair as u32;
-        event.sport = (skport_pair >> 16) as u16;
-        event.dport = skport_pair as u16;
-        event.dport = event.dport.rotate_left(8);
+        parse_v4_sock(event, s);
     }
     if event.saddr == 0 || event.daddr == 0 || event.sport == 0 || event.dport == 0 {
         return Err(0);
@@ -127,20 +158,7 @@ fn try_tcp_v6_connect(ctx: FExitContext, event: &mut Event, expose: bool) -> Res
 
     unsafe {
         let s = ctx.arg::<*const sock>(0);
-        let skport_pair = (*s).__sk_common.__bindgen_anon_3.skc_portpair;
-        bpf_probe_read_kernel_buf(
-            &(*s).__sk_common.skc_v6_daddr.in6_u.u6_addr8 as *const _,
-            &mut event.daddr,
-        )
-        .map_err(|_| 0u32)?;
-        bpf_probe_read_kernel_buf(
-            &(*s).__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 as *const _,
-            &mut event.saddr,
-        )
-        .map_err(|_| 0u32)?;
-        event.sport = (skport_pair >> 16) as u16;
-        event.dport = skport_pair as u16;
-        event.dport = event.dport.rotate_left(8);
+        parse_v6_sock(event, s)?;
     }
     if event.sport == 0 || event.dport == 0 {
         return Err(0);
@@ -150,4 +168,61 @@ fn try_tcp_v6_connect(ctx: FExitContext, event: &mut Event, expose: bool) -> Res
         util::copy_proc(proc, &mut event.process);
     }
     Ok(0)
+}
+
+#[fexit(function = "tcp_close")]
+pub fn tcp_close_capture(ctx: FExitContext) -> u32 {
+    let Some(config_ptr) = NETMON_CONFIG.get_ptr(0) else {
+        return 0;
+    };
+    let config = unsafe { config_ptr.as_ref() };
+    let Some(config) = config else {
+        return 0;
+    };
+    event_capture!(ctx, MSG_NETWORK, false, try_tcp_close, config.expose_events)
+}
+
+fn try_tcp_close(ctx: FExitContext, event: &mut Event, expose: bool) -> Result<u32, u32> {
+    let Event::Network(event) = event else {
+        return Err(0);
+    };
+    let pid = ctx.pid();
+    let proc = unsafe { PROCMON_PROC_MAP.get(&pid) };
+    let Some(proc) = proc else {
+        return Err(0);
+    };
+
+    unsafe {
+        let s = ctx.arg::<*const sock>(0);
+        let family = (*s).__sk_common.skc_family;
+        match family {
+            AF_INET => {
+                let p = event as *mut NetworkMsg as *mut u8;
+                // TcpConV4Closed
+                *p = 2;
+                let NetworkMsg::TcpConV4Close(event) = event else {
+                    return Err(0);
+                };
+                parse_v4_sock(event, s);
+                if expose {
+                    util::copy_proc(proc, &mut event.process);
+                }
+                Ok(0)
+            }
+            AF_INET6 => {
+                let p = event as *mut NetworkMsg as *mut u8;
+                // TcpConV6Closed
+                *p = 3;
+                let NetworkMsg::TcpConV6Close(event) = event else {
+                    return Err(0);
+                };
+                parse_v6_sock(event, s)?;
+                if expose {
+                    util::copy_proc(proc, &mut event.process);
+                }
+                Ok(0)
+            }
+            _ => Err(0),
+        }
+    }
 }

--- a/bombini/src/detector/filemon.rs
+++ b/bombini/src/detector/filemon.rs
@@ -4,7 +4,6 @@ use aya::maps::Array;
 use aya::programs::Lsm;
 use aya::{Btf, Ebpf, EbpfError};
 
-use procfs::sys::kernel::Version;
 use yaml_rust2::{Yaml, YamlLoader};
 
 use std::path::Path;
@@ -19,10 +18,6 @@ pub struct FileMon {
 }
 
 impl Detector for FileMon {
-    fn min_kenrel_verison(&self) -> Version {
-        Version::new(5, 11, 0)
-    }
-
     async fn new<U: AsRef<Path>>(
         obj_path: U,
         config_path: Option<U>,

--- a/bombini/src/detector/gtfobins.rs
+++ b/bombini/src/detector/gtfobins.rs
@@ -4,7 +4,6 @@ use aya::maps::lpm_trie::{Key, LpmTrie};
 use aya::programs::Lsm;
 use aya::{Btf, Ebpf, EbpfError};
 
-use procfs::sys::kernel::Version;
 use yaml_rust2::{Yaml, YamlLoader};
 
 use bombini_common::config::gtfobins::GTFOBinsKey;
@@ -25,10 +24,6 @@ struct GTFOBinsConfig {
 }
 
 impl Detector for GTFOBinsDetector {
-    fn min_kenrel_verison(&self) -> Version {
-        Version::new(5, 11, 0)
-    }
-
     async fn new<U: AsRef<Path>>(
         obj_path: U,
         config_path: Option<U>,

--- a/bombini/src/detector/histfile.rs
+++ b/bombini/src/detector/histfile.rs
@@ -6,8 +6,6 @@ use aya::maps::lpm_trie::{Key, LpmTrie};
 use aya::programs::UProbe;
 use aya::{Ebpf, EbpfError};
 
-use procfs::sys::kernel::Version;
-
 use std::path::Path;
 
 use super::{load_ebpf_obj, Detector};
@@ -17,10 +15,6 @@ pub struct HistFileDetector {
 }
 
 impl Detector for HistFileDetector {
-    fn min_kenrel_verison(&self) -> Version {
-        Version::new(5, 11, 0)
-    }
-
     async fn new<U: AsRef<Path>>(
         obj_path: U,
         _config_path: Option<U>,

--- a/bombini/src/detector/io_uring.rs
+++ b/bombini/src/detector/io_uring.rs
@@ -3,8 +3,6 @@
 use aya::programs::BtfTracePoint;
 use aya::{Btf, Ebpf, EbpfError};
 
-use procfs::sys::kernel::Version;
-
 use std::path::Path;
 
 use super::{load_ebpf_obj, Detector};
@@ -14,10 +12,6 @@ pub struct IOUringDetector {
 }
 
 impl Detector for IOUringDetector {
-    fn min_kenrel_verison(&self) -> Version {
-        Version::new(5, 11, 0)
-    }
-
     async fn new<U: AsRef<Path>>(
         obj_path: U,
         _config_path: Option<U>,

--- a/bombini/src/detector/mod.rs
+++ b/bombini/src/detector/mod.rs
@@ -14,6 +14,7 @@ pub mod filemon;
 pub mod gtfobins;
 pub mod histfile;
 pub mod io_uring;
+pub mod netmon;
 pub mod procmon;
 
 pub trait Detector {

--- a/bombini/src/detector/mod.rs
+++ b/bombini/src/detector/mod.rs
@@ -33,7 +33,9 @@ pub trait Detector {
         Self: Sized;
 
     /// Minimal supported kernel version for detector to load
-    fn min_kenrel_verison(&self) -> Version;
+    fn min_kenrel_verison(&self) -> Version {
+        Version::new(5, 11, 0)
+    }
 
     /// Initialize config maps for detector
     fn map_initialize(&mut self) -> Result<(), EbpfError> {

--- a/bombini/src/detector/netmon.rs
+++ b/bombini/src/detector/netmon.rs
@@ -4,7 +4,6 @@ use aya::maps::Array;
 use aya::programs::FExit;
 use aya::{Btf, Ebpf, EbpfError};
 
-use procfs::sys::kernel::Version;
 use yaml_rust2::YamlLoader;
 
 use std::path::Path;
@@ -18,10 +17,6 @@ pub struct NetMon {
     config: Option<Config>,
 }
 impl Detector for NetMon {
-    fn min_kenrel_verison(&self) -> Version {
-        Version::new(5, 11, 0)
-    }
-
     async fn new<U: AsRef<Path>>(
         obj_path: U,
         config_path: Option<U>,

--- a/bombini/src/detector/netmon.rs
+++ b/bombini/src/detector/netmon.rs
@@ -1,0 +1,77 @@
+//! Network monitor detector
+
+use aya::maps::Array;
+use aya::programs::FExit;
+use aya::{Btf, Ebpf, EbpfError};
+
+use procfs::sys::kernel::Version;
+use yaml_rust2::YamlLoader;
+
+use std::path::Path;
+
+use bombini_common::config::network::Config;
+
+use super::{load_ebpf_obj, Detector};
+
+pub struct NetMon {
+    ebpf: Ebpf,
+    config: Option<Config>,
+}
+impl Detector for NetMon {
+    fn min_kenrel_verison(&self) -> Version {
+        Version::new(5, 11, 0)
+    }
+
+    async fn new<U: AsRef<Path>>(
+        obj_path: U,
+        config_path: Option<U>,
+    ) -> Result<Self, anyhow::Error> {
+        let ebpf = load_ebpf_obj(obj_path).await?;
+        if let Some(config_path) = config_path {
+            let mut config = Config {
+                expose_events: false,
+            };
+
+            let s = std::fs::read_to_string(config_path.as_ref())?;
+            let docs = YamlLoader::load_from_str(&s)?;
+            let doc = &docs[0];
+
+            config.expose_events = doc["expose-events"].as_bool().unwrap_or(false);
+
+            Ok(NetMon {
+                ebpf,
+                config: Some(config),
+            })
+        } else {
+            Ok(NetMon { ebpf, config: None })
+        }
+    }
+
+    fn map_initialize(&mut self) -> Result<(), EbpfError> {
+        if let Some(config) = self.config {
+            let mut config_map: Array<_, Config> =
+                Array::try_from(self.ebpf.map_mut("NETMON_CONFIG").unwrap())?;
+            let _ = config_map.set(0, config, 0);
+        }
+        Ok(())
+    }
+
+    fn load_and_attach_programs(&mut self) -> Result<(), EbpfError> {
+        let btf = Btf::from_sys_fs()?;
+        let tcp_v4_connect: &mut FExit = self
+            .ebpf
+            .program_mut("tcp_v4_connect_capture")
+            .unwrap()
+            .try_into()?;
+        tcp_v4_connect.load("tcp_v4_connect", &btf)?;
+        tcp_v4_connect.attach()?;
+        let tcp_v6_connect: &mut FExit = self
+            .ebpf
+            .program_mut("tcp_v6_connect_capture")
+            .unwrap()
+            .try_into()?;
+        tcp_v6_connect.load("tcp_v6_connect", &btf)?;
+        tcp_v6_connect.attach()?;
+        Ok(())
+    }
+}

--- a/bombini/src/detector/netmon.rs
+++ b/bombini/src/detector/netmon.rs
@@ -74,6 +74,13 @@ impl Detector for NetMon {
             .try_into()?;
         tcp_close.load("tcp_close", &btf)?;
         tcp_close.attach()?;
+        let tcp_accept: &mut FExit = self
+            .ebpf
+            .program_mut("inet_csk_accept_capture")
+            .unwrap()
+            .try_into()?;
+        tcp_accept.load("inet_csk_accept", &btf)?;
+        tcp_accept.attach()?;
         Ok(())
     }
 }

--- a/bombini/src/detector/netmon.rs
+++ b/bombini/src/detector/netmon.rs
@@ -67,6 +67,13 @@ impl Detector for NetMon {
             .try_into()?;
         tcp_v6_connect.load("tcp_v6_connect", &btf)?;
         tcp_v6_connect.attach()?;
+        let tcp_close: &mut FExit = self
+            .ebpf
+            .program_mut("tcp_close_capture")
+            .unwrap()
+            .try_into()?;
+        tcp_close.load("tcp_close", &btf)?;
+        tcp_close.attach()?;
         Ok(())
     }
 }

--- a/bombini/src/detector/procmon.rs
+++ b/bombini/src/detector/procmon.rs
@@ -4,7 +4,6 @@ use aya::maps::Array;
 use aya::programs::{BtfTracePoint, FEntry, Lsm};
 use aya::{Btf, Ebpf, EbpfError};
 
-use procfs::sys::kernel::Version;
 use yaml_rust2::YamlLoader;
 
 use std::path::Path;
@@ -19,10 +18,6 @@ pub struct ProcMon {
 }
 
 impl Detector for ProcMon {
-    fn min_kenrel_verison(&self) -> Version {
-        Version::new(5, 11, 0)
-    }
-
     async fn new<U: AsRef<Path>>(
         obj_path: U,
         config_path: Option<U>,

--- a/bombini/src/registry.rs
+++ b/bombini/src/registry.rs
@@ -12,6 +12,7 @@ use crate::detector::histfile::HistFileDetector;
 use crate::detector::io_uring::IOUringDetector;
 
 use crate::detector::filemon::FileMon;
+use crate::detector::netmon::NetMon;
 use crate::detector::procmon::ProcMon;
 use crate::detector::Detector;
 
@@ -63,6 +64,11 @@ impl Registry {
                     let mut filemon = FileMon::new(&obj_path, Some(&config_path)).await?;
                     filemon.load()?;
                     self.detectors.insert(name.to_string(), Box::new(filemon));
+                }
+                "netmon" => {
+                    let mut netmon = NetMon::new(&obj_path, Some(&config_path)).await?;
+                    netmon.load()?;
+                    self.detectors.insert(name.to_string(), Box::new(netmon));
                 }
                 _ => return Err(anyhow!("{} unknown detector", name)),
             };

--- a/bombini/src/transmuter/file.rs
+++ b/bombini/src/transmuter/file.rs
@@ -6,7 +6,7 @@ use bitflags::bitflags;
 use serde::{Serialize, Serializer};
 
 use super::process::Process;
-use super::{Transmute, str_from_bytes};
+use super::{str_from_bytes, Transmute};
 
 bitflags! {
     #[derive(Clone, Debug, Serialize)]

--- a/bombini/src/transmuter/file.rs
+++ b/bombini/src/transmuter/file.rs
@@ -6,7 +6,7 @@ use bitflags::bitflags;
 use serde::{Serialize, Serializer};
 
 use super::process::Process;
-use super::Transmute;
+use super::{Transmute, str_from_bytes};
 
 bitflags! {
     #[derive(Clone, Debug, Serialize)]
@@ -213,15 +213,6 @@ impl FileEvent {
                 panic!("unsupported LSM BPF File hook");
             }
         }
-    }
-}
-
-fn str_from_bytes(bytes: &[u8]) -> String {
-    if *bytes.last().unwrap() == 0x0 {
-        let zero = bytes.iter().position(|e| *e == 0x0).unwrap();
-        String::from_utf8_lossy(&bytes[..zero]).to_string()
-    } else {
-        String::from_utf8_lossy(bytes).to_string()
     }
 }
 

--- a/bombini/src/transmuter/histfile.rs
+++ b/bombini/src/transmuter/histfile.rs
@@ -5,7 +5,7 @@ use bombini_common::event::histfile::HistFileMsg;
 use serde::Serialize;
 
 use super::process::Process;
-use super::Transmute;
+use super::{Transmute, str_from_bytes};
 
 /// High-level event representation
 #[derive(Clone, Debug, Serialize)]
@@ -20,15 +20,9 @@ pub struct HistFileEvent {
 impl HistFileEvent {
     /// Constructs High level event representation from low eBPF message
     pub fn new(event: HistFileMsg) -> Self {
-        let command = if *event.command.last().unwrap() == 0x0 {
-            let zero = event.command.iter().position(|e| *e == 0x0).unwrap();
-            String::from_utf8_lossy(&event.command[..zero]).to_string()
-        } else {
-            String::from_utf8_lossy(&event.command).to_string()
-        };
         Self {
             process: Process::new(event.process),
-            command,
+            command: str_from_bytes(&event.command),
         }
     }
 }

--- a/bombini/src/transmuter/histfile.rs
+++ b/bombini/src/transmuter/histfile.rs
@@ -5,7 +5,7 @@ use bombini_common::event::histfile::HistFileMsg;
 use serde::Serialize;
 
 use super::process::Process;
-use super::{Transmute, str_from_bytes};
+use super::{str_from_bytes, Transmute};
 
 /// High-level event representation
 #[derive(Clone, Debug, Serialize)]

--- a/bombini/src/transmuter/mod.rs
+++ b/bombini/src/transmuter/mod.rs
@@ -7,14 +7,17 @@ use file::FileEvent;
 use gtfobins::GTFOBinsEvent;
 use histfile::HistFileEvent;
 use io_uring::IOUringEvent;
+use network::NetworkEvent;
 use process::ProcessExec;
 use process::ProcessExit;
+
 use serde::Serialize;
 
 mod file;
 mod gtfobins;
 mod histfile;
 mod io_uring;
+mod network;
 mod process;
 
 /// Transmutes eBPF events from low representation into serialized formats
@@ -30,6 +33,7 @@ impl Transmuter {
             Event::GTFOBins(s) => Ok(GTFOBinsEvent::new(s).to_json()?.into_bytes()),
             Event::HistFile(s) => Ok(HistFileEvent::new(s).to_json()?.into_bytes()),
             Event::IOUring(s) => Ok(IOUringEvent::new(s).to_json()?.into_bytes()),
+            Event::Network(s) => Ok(NetworkEvent::new(s).to_json()?.into_bytes()),
         }
     }
 }

--- a/bombini/src/transmuter/mod.rs
+++ b/bombini/src/transmuter/mod.rs
@@ -43,3 +43,12 @@ trait Transmute {
         serde_json::to_string(&self)
     }
 }
+
+pub fn str_from_bytes(bytes: &[u8]) -> String {
+    if *bytes.last().unwrap() == 0x0 {
+        let zero = bytes.iter().position(|e| *e == 0x0).unwrap();
+        String::from_utf8_lossy(&bytes[..zero]).to_string()
+    } else {
+        String::from_utf8_lossy(bytes).to_string()
+    }
+}

--- a/bombini/src/transmuter/network.rs
+++ b/bombini/src/transmuter/network.rs
@@ -1,6 +1,6 @@
 //! Transmutes NetworkEvent to serialized format
 
-use bombini_common::event::network::NetworkMsg;
+use bombini_common::event::network::{NetworkMsg, TcpConnectionV4, TcpConnectionV6};
 use serde::Serialize;
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -23,7 +23,8 @@ pub struct NetworkEvent {
 #[repr(u8)]
 #[allow(dead_code)]
 pub enum NetworkEventType {
-    TcpConEstablish(TcpConnection),
+    TcpConnectionEstablish(TcpConnection),
+    TcpConnectionClose(TcpConnection),
 }
 
 /// TCP IPv4 connection information
@@ -38,6 +39,8 @@ pub struct TcpConnection {
     sport: u16,
     /// destination port
     dport: u16,
+    /// socket cookie
+    cookie: u64,
 }
 
 impl NetworkEvent {
@@ -45,32 +48,56 @@ impl NetworkEvent {
     pub fn new(event: NetworkMsg) -> Self {
         match event {
             NetworkMsg::TcpConV4Establish(con) => {
-                let s: [u8; 4] = Ipv4Addr::from_bits(con.saddr).octets();
-                let d: [u8; 4] = Ipv4Addr::from_bits(con.daddr).octets();
-                let con_event = TcpConnection {
-                    saddr: IpAddr::V4(Ipv4Addr::new(s[3], s[2], s[1], s[0])),
-                    daddr: IpAddr::V4(Ipv4Addr::new(d[3], d[2], d[1], d[0])),
-                    sport: con.sport,
-                    dport: con.dport,
-                };
+                let con_event = transmute_connection_v4(&con);
                 Self {
                     process: Process::new(con.process),
-                    network_event: NetworkEventType::TcpConEstablish(con_event),
+                    network_event: NetworkEventType::TcpConnectionEstablish(con_event),
                 }
             }
             NetworkMsg::TcpConV6Establish(con) => {
-                let con_event = TcpConnection {
-                    saddr: IpAddr::V6(Ipv6Addr::from_bits(u128::from_be_bytes(con.saddr))),
-                    daddr: IpAddr::V6(Ipv6Addr::from_bits(u128::from_be_bytes(con.daddr))),
-                    sport: con.sport,
-                    dport: con.dport,
-                };
+                let con_event = transmute_connection_v6(&con);
                 Self {
                     process: Process::new(con.process),
-                    network_event: NetworkEventType::TcpConEstablish(con_event),
+                    network_event: NetworkEventType::TcpConnectionEstablish(con_event),
+                }
+            }
+            NetworkMsg::TcpConV4Close(con) => {
+                let con_event = transmute_connection_v4(&con);
+                Self {
+                    process: Process::new(con.process),
+                    network_event: NetworkEventType::TcpConnectionClose(con_event),
+                }
+            }
+            NetworkMsg::TcpConV6Close(con) => {
+                let con_event = transmute_connection_v6(&con);
+                Self {
+                    process: Process::new(con.process),
+                    network_event: NetworkEventType::TcpConnectionClose(con_event),
                 }
             }
         }
+    }
+}
+
+fn transmute_connection_v4(con: &TcpConnectionV4) -> TcpConnection {
+    let s: [u8; 4] = Ipv4Addr::from_bits(con.saddr).octets();
+    let d: [u8; 4] = Ipv4Addr::from_bits(con.daddr).octets();
+    TcpConnection {
+        saddr: IpAddr::V4(Ipv4Addr::new(s[3], s[2], s[1], s[0])),
+        daddr: IpAddr::V4(Ipv4Addr::new(d[3], d[2], d[1], d[0])),
+        sport: con.sport,
+        dport: con.dport,
+        cookie: con.cookie,
+    }
+}
+
+fn transmute_connection_v6(con: &TcpConnectionV6) -> TcpConnection {
+    TcpConnection {
+        saddr: IpAddr::V6(Ipv6Addr::from_bits(u128::from_be_bytes(con.saddr))),
+        daddr: IpAddr::V6(Ipv6Addr::from_bits(u128::from_be_bytes(con.daddr))),
+        sport: con.sport,
+        dport: con.dport,
+        cookie: con.cookie,
     }
 }
 

--- a/bombini/src/transmuter/network.rs
+++ b/bombini/src/transmuter/network.rs
@@ -22,9 +22,11 @@ pub struct NetworkEvent {
 #[serde(tag = "type")]
 #[repr(u8)]
 #[allow(dead_code)]
+#[allow(clippy::enum_variant_names)]
 pub enum NetworkEventType {
     TcpConnectionEstablish(TcpConnection),
     TcpConnectionClose(TcpConnection),
+    TcpConnectionAccept(TcpConnection),
 }
 
 /// TCP IPv4 connection information
@@ -73,6 +75,20 @@ impl NetworkEvent {
                 Self {
                     process: Process::new(con.process),
                     network_event: NetworkEventType::TcpConnectionClose(con_event),
+                }
+            }
+            NetworkMsg::TcpConV4Accept(con) => {
+                let con_event = transmute_connection_v4(&con);
+                Self {
+                    process: Process::new(con.process),
+                    network_event: NetworkEventType::TcpConnectionAccept(con_event),
+                }
+            }
+            NetworkMsg::TcpConV6Accept(con) => {
+                let con_event = transmute_connection_v6(&con);
+                Self {
+                    process: Process::new(con.process),
+                    network_event: NetworkEventType::TcpConnectionAccept(con_event),
                 }
             }
         }

--- a/bombini/src/transmuter/process.rs
+++ b/bombini/src/transmuter/process.rs
@@ -4,7 +4,7 @@ use bombini_common::event::process::{ProcInfo, SecureExec};
 
 use serde::Serialize;
 
-use super::Transmute;
+use super::{str_from_bytes, Transmute};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "type")]
@@ -50,19 +50,6 @@ pub struct Process {
 impl Process {
     /// Constructs High level event representation from low eBPF
     pub fn new(mut proc: ProcInfo) -> Self {
-        let filename = if *proc.filename.last().unwrap() == 0x0 {
-            let zero = proc.filename.iter().position(|e| *e == 0x0).unwrap();
-            String::from_utf8_lossy(&proc.filename[..zero]).to_string()
-        } else {
-            String::from_utf8_lossy(&proc.filename).to_string()
-        };
-
-        let binary_path = if *proc.binary_path.last().unwrap() == 0x0 {
-            let zero = proc.binary_path.iter().position(|e| *e == 0x0).unwrap();
-            String::from_utf8_lossy(&proc.binary_path[..zero]).to_string()
-        } else {
-            String::from_utf8_lossy(&proc.binary_path).to_string()
-        };
 
         proc.args.iter_mut().for_each(|e| {
             if *e == 0x00 {
@@ -81,8 +68,8 @@ impl Process {
             cap_permitted: proc.creds.cap_permitted,
             cap_inheritable: proc.creds.cap_inheritable,
             secureexec: SecureExec::from_bits_truncate(proc.creds.secureexec.bits()),
-            filename,
-            binary_path,
+            filename: str_from_bytes(&proc.filename),
+            binary_path: str_from_bytes(&proc.binary_path),
             args,
         }
     }

--- a/bombini/src/transmuter/process.rs
+++ b/bombini/src/transmuter/process.rs
@@ -50,7 +50,6 @@ pub struct Process {
 impl Process {
     /// Constructs High level event representation from low eBPF
     pub fn new(mut proc: ProcInfo) -> Self {
-
         proc.args.iter_mut().for_each(|e| {
             if *e == 0x00 {
                 *e = 0x20

--- a/bombini/tests/tests.rs
+++ b/bombini/tests/tests.rs
@@ -281,3 +281,89 @@ fn test_filemon_unlink_file() {
 
     let _ = fs::remove_dir_all(bombini_temp_dir);
 }
+
+#[test]
+#[ignore = "Github CI runners doesn't support bpf LSM. TODO: Run tests in VM"]
+fn test_netmon_tcp_ip4_file() {
+    let (temp_dir, mut config, bpf_objs) = init_test_env();
+    let bombini_temp_dir = temp_dir.path();
+    let mut tmp_config = bombini_temp_dir.join("config/config.yaml");
+    let _ = fs::create_dir(bombini_temp_dir.join("config"));
+    let _ = fs::copy(&config, &tmp_config);
+    tmp_config.pop();
+    config.pop();
+    let _ = fs::copy(config.join("procmon.yaml"), tmp_config.join("procmon.yaml"));
+    let _ = fs::copy(config.join("netmon.yaml"), tmp_config.join("netmon.yaml"));
+    let bombini_log =
+        File::create(bombini_temp_dir.join("bombini.log")).expect("can't create log file");
+    let event_log = temp_dir.path().join("events.log");
+
+    let bombini = Command::new(EXE_BOMBINI)
+        .args([
+            "--config-dir",
+            tmp_config.to_str().unwrap(),
+            "--bpf-objs",
+            bpf_objs.to_str().unwrap(),
+            "--event-log",
+            event_log.to_str().unwrap(),
+            "--detector",
+            "procmon",
+            "--detector",
+            "netmon",
+        ])
+        .env("RUST_LOG", "debug")
+        .stderr(bombini_log.try_clone().unwrap())
+        .spawn();
+
+    if bombini.is_err() {
+        panic!("{:?}", bombini.err().unwrap());
+    }
+    let mut bombini = bombini.expect("failed to start bombini");
+    // Wait for detectors being loaded
+    thread::sleep(Duration::from_millis(1500));
+
+    let mut nc = Command::new("nc")
+        .args(["-l", "7878"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+        .expect("can't start nc");
+
+    // Wait nc
+    thread::sleep(Duration::from_millis(500));
+
+    let _ = Command::new("telnet")
+        .args(["localhost", "7878"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+        .expect("can't start nc");
+
+    // Wait Events being processed
+    thread::sleep(Duration::from_millis(500));
+
+    let _ = signal::kill(Pid::from_raw(nc.id() as i32), Signal::SIGKILL);
+
+    let _ = nc.wait().unwrap();
+
+    let _ = signal::kill(Pid::from_raw(bombini.id() as i32), Signal::SIGINT);
+
+    let _ = bombini.wait().unwrap();
+
+    // TODO: more precise check
+    let events = fs::read_to_string(&event_log).expect("can't read events");
+    // inet_csk_accept isn't triggered from tests don't know why
+    ma::assert_ge!(events.matches("\"type\":\"NetworkEvent\"").count(), 2);
+    assert_eq!(
+        events
+            .matches("\"type\":\"TcpConnectionEstablish\"")
+            .count(),
+        1
+    );
+    ma::assert_ge!(events.matches("\"type\":\"TcpConnectionClose\"").count(), 1);
+    assert_eq!(events.matches("\"args\":\"localhost 7878\"").count(), 2);
+
+    let _ = fs::remove_dir_all(bombini_temp_dir);
+}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,7 @@ procmon_proc_map_size: 8192
 detectors:
    - procmon
    - filemon
+   - netmon
    - gtfobins
    - histfile
    - io_uring

--- a/config/netmon.yaml
+++ b/config/netmon.yaml
@@ -1,0 +1,1 @@
+expose-events: true

--- a/docs/design.md
+++ b/docs/design.md
@@ -46,6 +46,7 @@ interact with them (change config maps).
 
 * [procmon](detectors/procmon.md)
 * [filemon](detectors/filemon.md)
+* [netmon](detectors/netmon.md)
 * [gtflobins](detectors/gtfobins.md)
 * [histfile](detectors/histfile.md)
 * [io_uring](detectors/io_uring.md)

--- a/docs/detectors/netmon.md
+++ b/docs/detectors/netmon.md
@@ -1,0 +1,176 @@
+## Netmon
+
+Netmon detector provides information about ingress/egress TCP connections
+based on IPv4/IPv6
+
+Hooks:
+
+- `tcp_v4_connect`: collect egnress TCP IPv4 connection requests
+- `tcp_v6_connect`: collect egnress TCP IPv6 connection requests
+- `tcp_close`: collect connection close events
+- `inet_csk_accept`: collect TCP v4/v6 ingress connections
+
+### Config
+
+```yaml
+expose-events: false
+```
+
+`expose-events` sends events to user-mode. False by default.
+
+### Event
+
+Executing `curl -6 google.com` produces:
+
+```json
+{
+  "type": "NetworkEvent",
+  "process": {
+    "pid": 2538344,
+    "tid": 2538344,
+    "ppid": 9425,
+    "uid": 1000,
+    "euid": 1000,
+    "auid": 1000,
+    "cap_inheritable": 0,
+    "cap_permitted": 0,
+    "cap_effective": 0,
+    "secureexec": "",
+    "filename": "curl",
+    "binary_path": "/usr/bin/curl",
+    "args": "-6 google.com"
+  },
+  "network_event": {
+    "type": "TcpConnectionEstablish",
+    "saddr": "fe80::d497:36b6:16bf:d97b",
+    "daddr": "2a00:1450:4010:c08::8b",
+    "sport": 33340,
+    "dport": 80,
+    "cookie": 4109
+  }
+}
+```
+
+```json
+{
+  "type": "NetworkEvent",
+  "process": {
+    "pid": 2538344,
+    "tid": 2538344,
+    "ppid": 9425,
+    "uid": 1000,
+    "euid": 1000,
+    "auid": 1000,
+    "cap_inheritable": 0,
+    "cap_permitted": 0,
+    "cap_effective": 0,
+    "secureexec": "",
+    "filename": "curl",
+    "binary_path": "/usr/bin/curl",
+    "args": "-6 google.com"
+  },
+  "network_event": {
+    "type": "TcpConnectionClose",
+    "saddr": "fe80::d497:36b6:16bf:d97b",
+    "daddr": "2a00:1450:4010:c08::8b",
+    "sport": 0,
+    "dport": 80,
+    "cookie": 4109
+  }
+}
+```
+Executing
+
+```bash
+nc -l 7878
+telnet localhost 7878
+```
+
+produce the following events:
+
+```json
+{
+  "type": "NetworkEvent",
+  "process": {
+    "pid": 2549606,
+    "tid": 2549606,
+    "ppid": 1434309,
+    "uid": 1000,
+    "euid": 1000,
+    "auid": 1000,
+    "cap_inheritable": 0,
+    "cap_permitted": 0,
+    "cap_effective": 0,
+    "secureexec": "",
+    "filename": "inetutils-telnet",
+    "binary_path": "/usr/bin/inetutils-telnet",
+    "args": "localhost 7878"
+  },
+  "network_event": {
+    "type": "TcpConnectionEstablish",
+    "saddr": "127.0.0.1",
+    "daddr": "127.0.0.1",
+    "sport": 38570,
+    "dport": 7878,
+    "cookie": 16387
+  }
+}
+```
+
+```json
+{
+  "type": "NetworkEvent",
+  "process": {
+    "pid": 2549020,
+    "tid": 2549020,
+    "ppid": 9425,
+    "uid": 1000,
+    "euid": 1000,
+    "auid": 1000,
+    "cap_inheritable": 0,
+    "cap_permitted": 0,
+    "cap_effective": 0,
+    "secureexec": "",
+    "filename": "nc.openbsd",
+    "binary_path": "/usr/bin/nc.openbsd",
+    "args": "-l 7878"
+  },
+  "network_event": {
+    "type": "TcpConnectionAccept",
+    "saddr": "0.0.0.0",
+    "daddr": "0.0.0.0",
+    "sport": 7878,
+    "dport": 0,
+    "cookie": 24591
+  }
+}
+```
+
+```json
+{
+  "type": "NetworkEvent",
+  "process": {
+    "pid": 2549606,
+    "tid": 2549606,
+    "ppid": 1434309,
+    "uid": 1000,
+    "euid": 1000,
+    "auid": 1000,
+    "cap_inheritable": 0,
+    "cap_permitted": 0,
+    "cap_effective": 0,
+    "secureexec": "",
+    "filename": "inetutils-telnet",
+    "binary_path": "/usr/bin/inetutils-telnet",
+    "args": "localhost 7878"
+  },
+  "network_event": {
+    "type": "TcpConnectionClose",
+    "saddr": "127.0.0.1",
+    "daddr": "127.0.0.1",
+    "sport": 0,
+    "dport": 7878,
+    "cookie": 16387
+  }
+}
+```


### PR DESCRIPTION
NetMon provides information about egress TCP connections based on IPv4/Ipv6. Events include either success or failed connections.

- [x]  Basic Implementation: Connect/Accept/Close for TCP (IPv4/IPv6)
- [x] Some tests
- [x] Docs
Also we need to think about enriching events with FQDNs. It's hard to do on eBPF side. We need to parse  DNS packets (UDP 53). Maybe it is not possible with Tracing programs, and we cause big overhead. Maybe it's better way to enrich events in user mode with reverse DNS? But we might have problems with DNS response ttl. We need to try both approaches and decide which is better.
